### PR TITLE
fix: deprecated apis MV3

### DIFF
--- a/src/background/presenters/Notifier.ts
+++ b/src/background/presenters/Notifier.ts
@@ -1,12 +1,9 @@
 import { injectable } from "inversify";
 
 const NOTIFICATION_ID_UPDATE = "vimmatic-update";
-const NOTIFICATION_ID_INVALID_SETTINGS = "vimmatic-update-invalid-settings";
 
 export default interface Notifier {
   notifyUpdated(version: string, onclick: () => void): Promise<void>;
-
-  notifyInvalidSettings(error: Error, onclick: () => void): Promise<void>;
 }
 
 @injectable()
@@ -27,31 +24,6 @@ export class NotifierImpl implements NotifierImpl {
     chrome.notifications.create(NOTIFICATION_ID_UPDATE, {
       type: "basic",
       iconUrl: chrome.runtime.getURL("resources/icon_48x48.png"),
-      title,
-      message,
-    });
-  }
-
-  async notifyInvalidSettings(
-    error: Error,
-    onclick: () => void
-  ): Promise<void> {
-    const title = `Loading settings failed`;
-    // eslint-disable-next-line max-len
-    const message = `The default settings are used due to the last saved settings is invalid.  Check your current settings from the add-on preference: ${error.message}`;
-
-    const listener = (id: string) => {
-      if (id !== NOTIFICATION_ID_INVALID_SETTINGS) {
-        return;
-      }
-      onclick();
-      chrome.notifications.onClicked.removeListener(listener);
-    };
-    chrome.notifications.onClicked.addListener(listener);
-
-    chrome.notifications.create(NOTIFICATION_ID_INVALID_SETTINGS, {
-      type: "basic",
-      iconUrl: chrome.extension.getURL("resources/icon_48x48.png"),
       title,
       message,
     });

--- a/src/background/presenters/ToolbarPresenter.ts
+++ b/src/background/presenters/ToolbarPresenter.ts
@@ -10,39 +10,13 @@ export default interface ToolbarPresenter {
 export class ToolbarPresenterImpl {
   async setEnabled(enabled: boolean): Promise<void> {
     const path = enabled
-      ? "resources/enabled_32x32.png"
-      : "resources/disabled_32x32.png";
+      ? "../resources/enabled_32x32.png"
+      : "../resources/disabled_32x32.png";
 
-    // chrome.action is supported on v3 api
-    if (
-      typeof chrome.action !== "undefined" &&
-      typeof chrome.action.setIcon === "function"
-    ) {
-      return chrome.action.setIcon({ path });
-    }
-
-    // firefox does not support chrome.action
-    if (
-      typeof chrome.browserAction !== "undefined" &&
-      typeof chrome.browserAction.setIcon === "function"
-    ) {
-      // v2 api on chromium requires callback on the 2nd argument
-      return new Promise((resolve) =>
-        chrome.browserAction.setIcon({ path }, resolve)
-      );
-    }
+    return chrome.action.setIcon({ path });
   }
 
   onClick(listener: (arg: chrome.tabs.Tab) => void): void {
-    // chrome.action is supported on v3 api
-    if (typeof chrome.action !== "undefined") {
-      chrome.action.onClicked.addListener(listener);
-      return;
-    }
-
-    // firefox does not support chrome.action
-    if (typeof chrome.browserAction !== "undefined") {
-      chrome.action.onClicked.addListener(listener);
-    }
+    chrome.action.onClicked.addListener(listener);
   }
 }


### PR DESCRIPTION
This change removes following APIs which deprecated on MV3.  AMO (addons.mozilla.org) scan submitted code and warn deprecated APIs. We can remove them safely because they are no longer used on production code
- `chrome.extension.getURL()`
- `chrome.browserAction`