### PR TITLE
fix: Fix issue that white rectangle appears in the foreground of the page 

### DIFF
--- a/src/content/presenters/ConsoleFramePresenter.ts
+++ b/src/content/presenters/ConsoleFramePresenter.ts
@@ -44,6 +44,7 @@ export class ConsoleFramePresenterImpl implements ConsoleFramePresenter {
       return;
     }
     ele.blur();
+    ele.style.height = "";
   }
 
   resize(_width: number, height: number): void {

--- a/src/content/site-style.ts
+++ b/src/content/site-style.ts
@@ -4,6 +4,7 @@ export default `
   padding: 0;
   bottom: 0;
   left: 0;
+  height: 0;
   width: 100%;
   position: fixed;
   z-index: 2147483647;


### PR DESCRIPTION
This PR fixes the issue reported on vim-vixen (https://github.com/ueokande/vim-vixen/issues/1424).  The iframe of the console appears in the foreground of the page, and it overlays the page on several pages.