### PR TITLE
fix: open default URL on chromium by gh/gH

### DIFF
--- a/src/background/di.ts
+++ b/src/background/di.ts
@@ -6,7 +6,10 @@ import { NotifierImpl } from "./presenters/Notifier";
 import { ContentMessageClientImpl } from "./clients/ContentMessageClient";
 import { NavigateClientImpl } from "./clients/NavigateClient";
 import { ConsoleClientImpl } from "./clients/ConsoleClient";
-import { BrowserSettingRepositoryImpl } from "./repositories/BrowserSettingRepository";
+import {
+  FirefoxBrowserSettingRepositoryImpl,
+  ChromeBrowserSettingRepositoryImpl,
+} from "./repositories/BrowserSettingRepository";
 import { RepeatRepositoryImpl } from "./repositories/RepeatRepository";
 import { FindClientImpl } from "./clients/FindClient";
 import { ConsoleFrameClientImpl } from "./clients/ConsoleFrameClient";
@@ -37,7 +40,6 @@ const container = new Container({ autoBindInjectable: true });
 
 container.bind("LastSelectedTabRepository").to(LastSelectedTabRepositoryImpl);
 container.bind("Notifier").to(NotifierImpl);
-container.bind("BrowserSettingRepository").to(BrowserSettingRepositoryImpl);
 container.bind("RepeatRepository").to(RepeatRepositoryImpl);
 container.bind("FindRepository").to(FindRepositoryImpl);
 container.bind("FindClient").to(FindClientImpl);
@@ -48,8 +50,14 @@ container.bind("ConsoleFrameClient").to(ConsoleFrameClientImpl);
 container.bind("ReadyFrameRepository").to(ReadyFrameRepositoryImpl);
 if (process.env.BROWSER === "firefox") {
   container.bind("ClipboardRepository").to(FirefoxClipboardRepositoryImpl);
+  container
+    .bind("BrowserSettingRepository")
+    .to(FirefoxBrowserSettingRepositoryImpl);
 } else {
   container.bind("ClipboardRepository").to(ChromeClipboardRepositoryImpl);
+  container
+    .bind("BrowserSettingRepository")
+    .to(ChromeBrowserSettingRepositoryImpl);
 }
 container.bind("PropertySettings").to(PropertySettingsImpl);
 container.bind("SearchEngineSettings").to(SearchEngineSettingsImpl);

--- a/src/background/operators/impls/OpenHomeOperator.ts
+++ b/src/background/operators/impls/OpenHomeOperator.ts
@@ -26,12 +26,6 @@ export default class OpenHomeOperator implements Operator {
     { newTab }: z.infer<ReturnType<OpenHomeOperator["schema"]>>
   ): Promise<void> {
     const urls = await this.browserSettingRepository.getHomepageUrls();
-    if (urls.length === 1 && urls[0] === "about:home") {
-      // eslint-disable-next-line max-len
-      throw new Error(
-        "Cannot open Firefox Home (about:home) by WebExtensions, set your custom URLs"
-      );
-    }
     if (urls.length === 1 && !newTab) {
       await chrome.tabs.update({ url: urls[0] });
       return;

--- a/src/background/repositories/BrowserSettingRepository.ts
+++ b/src/background/repositories/BrowserSettingRepository.ts
@@ -6,9 +6,33 @@ export default interface BrowserSettingRepository {
 }
 
 @injectable()
-export class BrowserSettingRepositoryImpl implements BrowserSettingRepository {
+export class FirefoxBrowserSettingRepositoryImpl
+  implements BrowserSettingRepository
+{
   async getHomepageUrls(): Promise<string[]> {
     const { value } = await chrome.browserSettings.homepageOverride.get({});
-    return value.split("|").map(urls.normalizeUrl);
+    const normalizedURLs = value
+      .split("|")
+      .map((u) => u.trim())
+      .filter((u) => u.length > 0)
+      .map(urls.normalizeUrl)
+      .filter(
+        // firefox does not supports about:blank
+        (u) => !u.startsWith("about:") || u === "about:blank"
+      );
+    if (normalizedURLs.length === 0) {
+      return ["about:blank"];
+    }
+    return normalizedURLs;
+  }
+}
+
+@injectable()
+export class ChromeBrowserSettingRepositoryImpl
+  implements BrowserSettingRepository
+{
+  async getHomepageUrls(): Promise<string[]> {
+    // chrome does not supports browserSettings APIs
+    return ["chrome://newtab"];
   }
 }

--- a/test/background/repositories/BrowserSettingRepository.test.ts
+++ b/test/background/repositories/BrowserSettingRepository.test.ts
@@ -1,0 +1,69 @@
+import {
+  FirefoxBrowserSettingRepositoryImpl,
+  ChromeBrowserSettingRepositoryImpl,
+} from "../../../src/background/repositories/BrowserSettingRepository";
+
+describe("FirefoxBrowserSettingRepositoryImpl", () => {
+  const mockHomepageOverrideGet = jest.spyOn(
+    chrome.browserSettings.homepageOverride,
+    "get"
+  );
+  const sut = new FirefoxBrowserSettingRepositoryImpl();
+
+  beforeEach(() => {
+    mockHomepageOverrideGet.mockClear();
+  });
+
+  it("returns homepage urls", async () => {
+    mockHomepageOverrideGet.mockResolvedValue({
+      value: "google.com|yahoo.com|https://bing.com/",
+      levelOfControl: "not_controllable",
+    });
+
+    const urls = await sut.getHomepageUrls();
+    expect(urls).toEqual([
+      "http://google.com",
+      "http://yahoo.com",
+      "https://bing.com/",
+    ]);
+  });
+
+  it("excludes restricted urls", async () => {
+    mockHomepageOverrideGet.mockResolvedValue({
+      value: "about:blank|about:about|about:newtab",
+      levelOfControl: "not_controllable",
+    });
+
+    const urls = await sut.getHomepageUrls();
+    expect(urls).toEqual(["about:blank"]);
+  });
+
+  it("returns default url on empty value", async () => {
+    mockHomepageOverrideGet.mockResolvedValue({
+      value: "",
+      levelOfControl: "not_controllable",
+    });
+
+    const urls = await sut.getHomepageUrls();
+    expect(urls).toEqual(["about:blank"]);
+  });
+
+  it("returns default url on filtered URLs", async () => {
+    mockHomepageOverrideGet.mockResolvedValue({
+      value: "about:newtab|about:about",
+      levelOfControl: "not_controllable",
+    });
+
+    const urls = await sut.getHomepageUrls();
+    expect(urls).toEqual(["about:blank"]);
+  });
+});
+
+describe("ChromeBrowserSettingRepositoryImpl", () => {
+  const sut = new ChromeBrowserSettingRepositoryImpl();
+
+  it("returns default url", async () => {
+    const urls = await sut.getHomepageUrls();
+    expect(urls).toEqual(["chrome://newtab"]);
+  });
+});

--- a/test/main.ts
+++ b/test/main.ts
@@ -35,4 +35,9 @@ global.chrome = {
     getRecentlyClosed: todo,
     restore: todo,
   },
+  browserSettings: {
+    homepageOverride: {
+      get: todo,
+    },
+  },
 } as unknown as typeof chrome;


### PR DESCRIPTION
Firefox supports homepage settings of user preferences via `chrome.browserSettings.homepageOverride`, but chrome does not support it.  Now, vimmatic opens `chrome://newtab` on chromium by <kbd>g</kbd>+<kbd>h</kbd> and <kbd>g</kbd>+<kbd>H</kbd> key maps.