### PR TITLE
fix: resize when a message is shown on console

### DIFF
--- a/src/console/components/ErrorMessage.tsx
+++ b/src/console/components/ErrorMessage.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "../colorscheme/styled";
+import useAutoResize from "../hooks/useAutoResize";
 
 const Wrapper = styled.p`
   border-top: 1px solid gray;
@@ -9,6 +10,8 @@ const Wrapper = styled.p`
 `;
 
 const ErrorMessage: React.FC = ({ children }) => {
+  useAutoResize();
+
   return <Wrapper role="alert">{children}</Wrapper>;
 };
 

--- a/src/console/components/InfoMessage.tsx
+++ b/src/console/components/InfoMessage.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "../colorscheme/styled";
+import useAutoResize from "../hooks/useAutoResize";
 
 const Wrapper = styled.p`
   border-top: 1px solid gray;
@@ -9,6 +10,8 @@ const Wrapper = styled.p`
 `;
 
 const InfoMessage: React.FC = ({ children }) => {
+  useAutoResize();
+
   return <Wrapper role="status">{children}</Wrapper>;
 };
 


### PR DESCRIPTION
This PR fixes new issue caused by #97.  The message does not appear by the previous change. 