### PR TITLE
chore: fix compression method

### DIFF
--- a/script/package
+++ b/script/package
@@ -32,7 +32,11 @@ const zipPackage = async (browser) => {
 
   await new Promise((resolve, reject) => {
     zip
-      .generateNodeStream({ type: "nodebuffer", streamFiles: true })
+      .generateNodeStream({
+        type: "nodebuffer",
+        streamFiles: true,
+        compression: "DEFLATE",
+      })
       .pipe(fs.createWriteStream(output))
       .on("finish", resolve)
       .on("error", reject);


### PR DESCRIPTION
Chrome store does not accept a zip file compressed by `STORE` compression method (no compression).  Set compression method `DEFLATE` on `package` script.