### PR TITLE
fix "unsupported operation" error on set command

### DIFF
--- a/src/background/di.ts
+++ b/src/background/di.ts
@@ -21,7 +21,10 @@ import {
 } from "./repositories/ClipboardRepository";
 import { PropertySettingsImpl } from "./settings/PropertySettings";
 import { SearchEngineSettingsImpl } from "./settings/SearchEngineSettings";
-import { SettingsRepositoryImpl } from "./settings/SettingsRepository";
+import {
+  TransientSettingsRepository,
+  PermanentSettingsRepository,
+} from "./settings/SettingsRepository";
 import { KeyCaptureClientImpl } from "./clients/KeyCaptureClient";
 import { MarkRepositoryImpl } from "./repositories/MarkRepository";
 import { MarkModeRepositoryImpl } from "./repositories/MarkModeRepository";
@@ -71,7 +74,8 @@ container.bind("TopFrameClient").to(TopFrameClientImpl);
 container.bind("AddonEnabledRepository").to(AddonEnabledRepositoryImpl);
 container.bind("AddonEnabledClient").to(AddonEnabledClientImpl);
 container.bind("ToolbarPresenter").to(ToolbarPresenterImpl);
-container.bind("SettingsRepository").to(SettingsRepositoryImpl);
+container.bind("PermanentSettingsRepository").to(PermanentSettingsRepository);
+container.bind("SettingsRepository").to(TransientSettingsRepository);
 container
   .bind("PropertyRegistry")
   .toConstantValue(new PropertyRegistryFactry().create());

--- a/src/background/usecases/SettingsEventUseCase.ts
+++ b/src/background/usecases/SettingsEventUseCase.ts
@@ -6,7 +6,7 @@ import EventUseCaseHelper from "./EventUseCaseHelper";
 @injectable()
 export default class SettingsUseCase {
   constructor(
-    @inject("SettingsRepository")
+    @inject("PermanentSettingsRepository")
     private readonly settingsRepository: SettingsRepository,
     @inject("ContentMessageClient")
     private readonly contentMessageClient: ContentMessageClient,

--- a/test/background/settings/SettingsRepository.test.ts
+++ b/test/background/settings/SettingsRepository.test.ts
@@ -1,0 +1,139 @@
+import {
+  PermanentSettingsRepository,
+  TransientSettingsRepository,
+} from "../../../src/background/settings/SettingsRepository";
+import type Settings from "../../../src/shared/Settings";
+import MockLocalStorage from "../mock/MockLocalStorage";
+
+describe("PermanentSettingsRepository", () => {
+  const mockStorageGet = jest.spyOn(chrome.storage.sync, "get");
+
+  const sut = new PermanentSettingsRepository();
+
+  beforeEach(() => {
+    mockStorageGet.mockClear();
+  });
+
+  describe("#load", () => {
+    it("returns default settings", async () => {
+      mockStorageGet.mockResolvedValue({ settings: undefined });
+
+      const settings = await sut.load();
+      expect(settings.properties["complete"]).toBe("sbh");
+    });
+
+    it("returns current settings", async () => {
+      mockStorageGet.mockResolvedValue({
+        settings: {
+          properties: {
+            complete: "ssbbhh",
+          },
+        },
+      });
+
+      const settings = await sut.load();
+      expect(settings.properties["complete"]).toBe("ssbbhh");
+    });
+  });
+
+  describe("#save", () => {
+    it("throws an error", () => {
+      expect(sut.save({})).rejects.toThrowError();
+    });
+  });
+});
+
+class MockSettingsRepository {
+  private readonly listeners: Array<(settings: Settings) => unknown> = [];
+
+  save(): Promise<void> {
+    throw new Error("not implemented");
+  }
+
+  load(): Promise<Settings> {
+    throw new Error("not implemented");
+  }
+
+  onChanged(l: (settings: Settings) => unknown) {
+    this.listeners.push(l);
+  }
+
+  invalidate(settings: Settings) {
+    this.listeners.forEach((l) => l(settings));
+  }
+}
+
+describe("TransientSettingsRepository", () => {
+  const permanent = new MockSettingsRepository();
+  const mockPermanetLoad = jest.spyOn(permanent, "load");
+
+  mockPermanetLoad.mockResolvedValue({
+    properties: {
+      complete: "sbh",
+    },
+  });
+
+  beforeEach(() => {
+    mockPermanetLoad.mockClear();
+  });
+
+  describe("#load", () => {
+    const sut = new TransientSettingsRepository(
+      permanent,
+      new MockLocalStorage(undefined)
+    );
+
+    it("loads delegated value and caches it", async () => {
+      const settings1 = await sut.load();
+      expect(settings1.properties["complete"]).toBe("sbh");
+
+      const settings2 = await sut.load();
+      expect(settings2.properties["complete"]).toBe("sbh");
+
+      expect(mockPermanetLoad).toBeCalledTimes(1);
+    });
+  });
+
+  describe("#save", () => {
+    const sut = new TransientSettingsRepository(
+      permanent,
+      new MockLocalStorage(undefined)
+    );
+
+    it("saves to a permanent storage", async () => {
+      const settings1 = await sut.load();
+      expect(settings1.properties["complete"]).toBe("sbh");
+
+      await sut.save({ properties: { complete: "ssbbhh" } });
+
+      const settings2 = await sut.load();
+      expect(settings2.properties["complete"]).toBe("ssbbhh");
+    });
+  });
+
+  describe("#sync", () => {
+    const sut = new TransientSettingsRepository(
+      permanent,
+      new MockLocalStorage(undefined)
+    );
+
+    it("syncs to a permanent storage", async () => {
+      const settings1 = await sut.load();
+      expect(settings1.properties["complete"]).toBe("sbh");
+
+      await sut.save({ properties: { complete: "ssbbhh" } });
+
+      const settings2 = await sut.load();
+      expect(settings2.properties["complete"]).toBe("ssbbhh");
+
+      permanent.invalidate({
+        properties: {
+          complete: "hbs",
+        },
+      });
+
+      const settings3 = await sut.load();
+      expect(settings3.properties["complete"]).toBe("hbs");
+    });
+  });
+});

--- a/test/main.ts
+++ b/test/main.ts
@@ -40,4 +40,12 @@ global.chrome = {
       get: todo,
     },
   },
+  storage: {
+    sync: {
+      get: todo,
+      onChanged: {
+        addListener: todo,
+      },
+    },
+  },
 } as unknown as typeof chrome;


### PR DESCRIPTION
Set command outputs an error "unsupported operation".  This error is caused by #96, which removed cached settings.  An user can update properties by "set" command and the updated values are stored in the cached settings.  This change reverts caches settings and names it "TransientSettings".  The loaded settings and updated properties by the user are stored in it.