### PR TITLE
fix: global jump does not switch tabs

### DIFF
--- a/src/background/usecases/MarkJumpUseCase.ts
+++ b/src/background/usecases/MarkJumpUseCase.ts
@@ -43,6 +43,7 @@ export default class MarkJumpUseCase {
     const smooth = (await this.propertySettings.getProperty(
       "smoothscroll"
     )) as boolean;
+
     try {
       await this.contentMessageClient.scrollTo(
         mark.tabId,
@@ -51,7 +52,7 @@ export default class MarkJumpUseCase {
         mark.y,
         smooth
       );
-      await chrome.tabs.update(tabId, { active: true });
+      await chrome.tabs.update(mark.tabId, { active: true });
       return;
     } catch (e) {
       const tab = await chrome.tabs.create({ url: mark.url });

--- a/test/background/usecases/MarkJumpUseCase.test.ts
+++ b/test/background/usecases/MarkJumpUseCase.test.ts
@@ -38,7 +38,7 @@ describe("MarkJumpUseCase", () => {
     const mockGetGlobalMark = jest
       .spyOn(markRepository, "getGlobalMark")
       .mockResolvedValue({
-        tabId: 100,
+        tabId: 101,
         url: "https://example.com/",
         x: 10,
         y: 20,
@@ -53,8 +53,8 @@ describe("MarkJumpUseCase", () => {
     await sut.jumpToMark("A");
 
     expect(mockGetGlobalMark).toHaveBeenCalledWith("A");
-    expect(mockScrollTo).toHaveBeenCalledWith(100, 0, 10, 20, true);
-    expect(mockTabsUpdate).toHaveBeenCalledWith(100, { active: true });
+    expect(mockScrollTo).toHaveBeenCalledWith(101, 0, 10, 20, true);
+    expect(mockTabsUpdate).toHaveBeenCalledWith(101, { active: true });
   });
 
   it("reopens tabs when the tab of the global mark is gone", async () => {


### PR DESCRIPTION
This PR fixes the issue on global mark.  Jumping to a global mark did not switch tabs. 