### PR TITLE
feat: show current value on set commnd

### DIFF
--- a/src/background/command/index.ts
+++ b/src/background/command/index.ts
@@ -67,7 +67,11 @@ export class CommandRegistryFactory {
     registory.register(new QuitAllCommand());
     registory.register(new QuitCommand());
     registory.register(
-      new SetCommand(this.propertySettings, this.propertyRegistry)
+      new SetCommand(
+        this.propertySettings,
+        this.propertyRegistry,
+        this.consoleClient
+      )
     );
 
     return registory;

--- a/src/background/settings/PropertySettings.ts
+++ b/src/background/settings/PropertySettings.ts
@@ -1,6 +1,6 @@
 import { injectable, inject } from "inversify";
-import PropertyRegistry from "../property/PropertyRegistry";
-import SettingsRepository from "./SettingsRepository";
+import type PropertyRegistry from "../property/PropertyRegistry";
+import type SettingsRepository from "./SettingsRepository";
 
 export default interface PropertySettings {
   setProperty(name: string, value: string | number | boolean): Promise<void>;

--- a/src/console/components/InfoMessage.tsx
+++ b/src/console/components/InfoMessage.tsx
@@ -7,6 +7,7 @@ const Wrapper = styled.p`
   background-color: ${({ theme }) => theme.info?.background};
   color: ${({ theme }) => theme.info?.foreground};
   font-weight: normal;
+  white-space: pre-wrap;
 `;
 
 const InfoMessage: React.FC = ({ children }) => {

--- a/test/background/command/SetCommand.test.ts
+++ b/test/background/command/SetCommand.test.ts
@@ -1,59 +1,181 @@
 import SetCommand from "../../../src/background/command/SetCommand";
-import { PropertyRegistryFactry } from "../../../src/background/property";
+import type { CommandContext } from "../../../src/background/command/Command";
+import { PropertyRegistryImpl } from "../../../src/background/property/PropertyRegistry";
 import MockPropertySettings from "../mock/MockPropertySettings";
+import MockConsoleClient from "../mock/MockConsoleClient";
+
+const strprop1 = {
+  name: () => "strprop1",
+  description: () => "",
+  type: () => "string" as const,
+  defaultValue: () => "foo",
+  validate: () => {},
+};
+
+const strprop2 = {
+  name: () => "strprop2",
+  description: () => "",
+  type: () => "string" as const,
+  defaultValue: () => "bar",
+  validate: () => {},
+};
+
+const booleanprop = {
+  name: () => "booleanprop",
+  description: () => "",
+  type: () => "boolean" as const,
+  defaultValue: () => false,
+  validate: () => {},
+};
 
 describe("SetCommand", () => {
   const propertySettings = new MockPropertySettings();
-  const propertyRegistry = new PropertyRegistryFactry().create();
+  const propertyRegistry = new PropertyRegistryImpl();
+  const consoleClient = new MockConsoleClient();
+  const ctx = {
+    sender: {
+      tabId: 10,
+    },
+  } as CommandContext;
+
+  propertyRegistry.register(strprop1);
+  propertyRegistry.register(strprop2);
+  propertyRegistry.register(booleanprop);
 
   describe("exec", () => {
     const mockSetProperty = jest.spyOn(propertySettings, "setProperty");
+    const mockGetProperty = jest.spyOn(propertySettings, "getProperty");
+    const mockShowInfo = jest.spyOn(consoleClient, "showInfo");
+    const cmd = new SetCommand(
+      propertySettings,
+      propertyRegistry,
+      consoleClient
+    );
 
     beforeEach(() => {
       mockSetProperty.mockClear();
-
       mockSetProperty.mockResolvedValue();
+      mockGetProperty.mockClear();
+      mockShowInfo.mockClear();
+      mockShowInfo.mockResolvedValue();
     });
 
     it("saves string property", async () => {
-      const cmd = new SetCommand(propertySettings, propertyRegistry);
-      await cmd.exec({} as any, false, "hintchars=abcdef");
+      await cmd.exec(ctx, false, "strprop1=newvalue");
+      expect(mockSetProperty).toHaveBeenCalledWith("strprop1", "newvalue");
+    });
 
-      expect(mockSetProperty).toHaveBeenCalledWith("hintchars", "abcdef");
+    it("shows string value with non value", async () => {
+      mockGetProperty.mockResolvedValue("saved-value");
+      await cmd.exec(ctx, false, "strprop1");
+      expect(mockShowInfo).toHaveBeenCalledWith(
+        ctx.sender.tabId,
+        "strprop1=saved-value"
+      );
+    });
+
+    it("shows string value with ?-suffix", async () => {
+      mockGetProperty.mockResolvedValue("saved-value");
+      await cmd.exec(ctx, false, "strprop1?");
+      expect(mockShowInfo).toHaveBeenCalledWith(
+        ctx.sender.tabId,
+        "strprop1=saved-value"
+      );
+    });
+
+    it("shows truthly boolean value with ?-suffix", async () => {
+      mockGetProperty.mockResolvedValue(true);
+      await cmd.exec(ctx, false, "booleanprop?");
+      expect(mockShowInfo).toHaveBeenCalledWith(
+        ctx.sender.tabId,
+        "booleanprop"
+      );
+    });
+
+    it("shows falsy boolean value with ?-suffix", async () => {
+      mockGetProperty.mockResolvedValue(false);
+      await cmd.exec(ctx, false, "booleanprop?");
+      expect(mockShowInfo).toHaveBeenCalledWith(
+        ctx.sender.tabId,
+        "nobooleanprop"
+      );
     });
 
     it("saves boolean property", async () => {
-      const cmd = new SetCommand(propertySettings, propertyRegistry);
+      await cmd.exec(ctx, false, "booleanprop");
+      expect(mockSetProperty).toHaveBeenCalledWith("booleanprop", true);
 
-      await cmd.exec({} as any, false, "smoothscroll");
-      expect(mockSetProperty).toHaveBeenCalledWith("smoothscroll", true);
+      await cmd.exec(ctx, false, "nobooleanprop");
+      expect(mockSetProperty).toHaveBeenCalledWith("booleanprop", false);
+    });
 
-      await cmd.exec({} as any, false, "nosmoothscroll");
-      expect(mockSetProperty).toHaveBeenCalledWith("smoothscroll", false);
+    it("shows all properties", async () => {
+      mockGetProperty.mockImplementation((name: string) => {
+        switch (name) {
+          case "strprop1":
+            return Promise.resolve("foo");
+          case "strprop2":
+            return Promise.resolve("bar");
+          case "booleanprop":
+            return Promise.resolve(false);
+        }
+        throw new Error("an error");
+      });
+      await cmd.exec(ctx, false, "");
+      expect(mockShowInfo).toHaveBeenCalledWith(
+        ctx.sender.tabId,
+        "strprop1=foo\nstrprop2=bar\nnobooleanprop"
+      );
+    });
+
+    it("throws error when invalid boolean statement", async () => {
+      await expect(cmd.exec(ctx, false, "booleanprop=1")).rejects.toThrowError(
+        "Invalid"
+      );
     });
   });
 
   describe("getCompletions", () => {
     it("returns all properties", async () => {
-      const cmd = new SetCommand(propertySettings, propertyRegistry);
+      const cmd = new SetCommand(
+        propertySettings,
+        propertyRegistry,
+        consoleClient
+      );
       const completions = await cmd.getCompletions(false, "");
       expect(completions).toHaveLength(1);
       expect(completions[0].items).toMatchObject([
-        { primary: "hintchars", value: "hintchars" },
-        { primary: "smoothscroll", value: "smoothscroll" },
-        { primary: "nosmoothscroll", value: "nosmoothscroll" },
-        { primary: "complete", value: "complete" },
-        { primary: "colorscheme", value: "colorscheme" },
+        { primary: "strprop1", value: "strprop1" },
+        { primary: "strprop2", value: "strprop2" },
+        { primary: "booleanprop", value: "booleanprop" },
+        { primary: "nobooleanprop", value: "nobooleanprop" },
       ]);
     });
 
     it("returns properties matched with a prefix", async () => {
-      const cmd = new SetCommand(propertySettings, propertyRegistry);
-      const completions = await cmd.getCompletions(false, "c");
+      const cmd = new SetCommand(
+        propertySettings,
+        propertyRegistry,
+        consoleClient
+      );
+      const completions = await cmd.getCompletions(false, "str");
       expect(completions).toHaveLength(1);
       expect(completions[0].items).toMatchObject([
-        { primary: "complete", value: "complete" },
-        { primary: "colorscheme", value: "colorscheme" },
+        { primary: "strprop1", value: "strprop1" },
+        { primary: "strprop2", value: "strprop2" },
+      ]);
+    });
+
+    it("returns properties matched with 'no' prefix", async () => {
+      const cmd = new SetCommand(
+        propertySettings,
+        propertyRegistry,
+        consoleClient
+      );
+      const completions = await cmd.getCompletions(false, "no");
+      expect(completions).toHaveLength(1);
+      expect(completions[0].items).toMatchObject([
+        { primary: "nobooleanprop", value: "nobooleanprop" },
       ]);
     });
   });

--- a/test/background/mock/MockConsoleClient.ts
+++ b/test/background/mock/MockConsoleClient.ts
@@ -17,7 +17,7 @@ export default class MockConsoleClient implements ConsoleClient {
     throw new Error("not implemented");
   }
 
-  showInfo(_tabId: number, _message: string): Promise<any> {
+  showInfo(_tabId: number, _message: string): Promise<void> {
     throw new Error("not implemented");
   }
 }


### PR DESCRIPTION
This change adds supporting current value of the property by vim-like command.  You can see the current value of the property `hintchars` by the following command.

```
:set hintchars 
``` 

This command also support `?`-suffix to show a boolean value:

```
:set smoothscroll?
```

If you omit property name, the add-on shows all properties and it's value:

```
:set
```