### PR TITLE
fix: white rectangle appers by Esc

### DIFF
--- a/src/content/presenters/ConsoleFramePresenter.ts
+++ b/src/content/presenters/ConsoleFramePresenter.ts
@@ -60,7 +60,7 @@ export class ConsoleFramePresenterImpl implements ConsoleFramePresenter {
       return;
     }
     ele.blur();
-    ele.style.height = "";
+    ele.style.setProperty("height", "0", "important");
   }
 
   resize(_width: number, height: number): void {


### PR DESCRIPTION
Close #151.  A white frame appears when users press Escape key at dark mode of GitHub.com.
This PR fixes it.