### PR TITLE
fix: use user's zoom level when resetting

### DIFF
--- a/src/background/operators/impls/ZoomResetOperator.ts
+++ b/src/background/operators/impls/ZoomResetOperator.ts
@@ -10,6 +10,6 @@ export default class ResetZoomOperator implements Operator {
   schema() {}
 
   async run(): Promise<void> {
-    return chrome.tabs.setZoom(1);
+    return chrome.tabs.setZoom(0);
   }
 }

--- a/test/background/operators/impls/ZoomResetOperator.test.ts
+++ b/test/background/operators/impls/ZoomResetOperator.test.ts
@@ -10,7 +10,7 @@ describe("ResetZoomOperator", () => {
       const sut = new ZoomResetOperator();
       await sut.run();
 
-      expect(mockSetZoom).toBeCalledWith(1);
+      expect(mockSetZoom).toBeCalledWith(0);
     });
   });
 });


### PR DESCRIPTION
If the user has a non-default zoom level configured, we should use it when resetting the zoom level