### PR TITLE
fix: replace incorrect or bad usages on styled-components

### DIFF
--- a/src/console/completion/components/CompletionItem.tsx
+++ b/src/console/completion/components/CompletionItem.tsx
@@ -2,17 +2,17 @@ import React from "react";
 import styled from "styled-components";
 
 const Container = styled.li<{
-  shown: number;
-  icon?: string;
-  highlight: number;
+  $shown: number;
+  $icon?: string;
+  $highlight: number;
 }>`
-  background-image: ${({ icon }) =>
-    typeof icon !== "undefined" ? "url(" + icon + ")" : "unset"};
-  background-color: ${({ highlight, theme }) =>
-    highlight ? theme.select?.background : theme.background};
-  color: ${({ highlight, theme }) =>
-    highlight ? theme.select?.foreground : theme.foreground};
-  display: ${({ shown }) => (shown ? "block" : "none")};
+  background-image: ${({ $icon }) =>
+    typeof $icon !== "undefined" ? "url(" + $icon + ")" : "unset"};
+  background-color: ${({ $highlight, theme }) =>
+    $highlight ? theme.select?.background : theme.background};
+  color: ${({ $highlight, theme }) =>
+    $highlight ? theme.select?.foreground : theme.foreground};
+  display: ${({ $shown }) => ($shown ? "block" : "none")};
   padding-left: 1.8rem;
   background-position: 0 center;
   background-size: contain;
@@ -53,9 +53,9 @@ const CompletionItem: React.FC<Props> = ({
 }) => (
   <Container
     aria-labelledby={`completion-item-${primary}`}
-    shown={Number(shown)}
-    icon={icon}
-    highlight={Number(highlight)}
+    $shown={Number(shown)}
+    $icon={icon}
+    $highlight={Number(highlight)}
     {...props}
   >
     <Primary id={`completion-item-${primary}`}>{primary}</Primary>

--- a/src/console/completion/components/CompletionItem.tsx
+++ b/src/console/completion/components/CompletionItem.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import styled from "styled-components";
 
 const Container = styled.li<{
-  shown: boolean;
+  shown: number;
   icon?: string;
-  highlight: boolean;
+  highlight: number;
 }>`
   background-image: ${({ icon }) =>
     typeof icon !== "undefined" ? "url(" + icon + ")" : "unset"};
@@ -43,10 +43,23 @@ interface Props extends React.HTMLAttributes<HTMLElement> {
   icon?: string;
 }
 
-const CompletionItem: React.FC<Props> = (props) => (
-  <Container aria-labelledby={`completion-item-${props.primary}`} {...props}>
-    <Primary id={`completion-item-${props.primary}`}>{props.primary}</Primary>
-    <Secondary>{props.secondary}</Secondary>
+const CompletionItem: React.FC<Props> = ({
+  shown,
+  highlight,
+  primary,
+  secondary,
+  icon,
+  ...props
+}) => (
+  <Container
+    aria-labelledby={`completion-item-${primary}`}
+    shown={Number(shown)}
+    icon={icon}
+    highlight={Number(highlight)}
+    {...props}
+  >
+    <Primary id={`completion-item-${primary}`}>{primary}</Primary>
+    <Secondary>{secondary}</Secondary>
   </Container>
 );
 

--- a/src/console/completion/components/CompletionTitle.tsx
+++ b/src/console/completion/components/CompletionTitle.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-const Li = styled.li<{ shown: boolean }>`
+const Li = styled.li<{ shown: number }>`
   display: ${({ shown }) => (shown ? "display" : "none")};
   background-color: ${({ theme }) => theme.title?.background};
   color: ${({ theme }) => theme.title?.foreground};
@@ -16,8 +16,10 @@ interface Props extends React.HTMLAttributes<HTMLElement> {
   title: string;
 }
 
-const CompletionTitle: React.FC<Props> = (props) => (
-  <Li {...props}>{props.title}</Li>
+const CompletionTitle: React.FC<Props> = ({ shown, title, ...props }) => (
+  <Li shown={Number(shown)} {...props}>
+    {title}
+  </Li>
 );
 
 export default CompletionTitle;

--- a/src/console/completion/components/CompletionTitle.tsx
+++ b/src/console/completion/components/CompletionTitle.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import styled from "styled-components";
 
-const Li = styled.li<{ shown: number }>`
-  display: ${({ shown }) => (shown ? "display" : "none")};
+const Li = styled.li<{ $shown: number }>`
+  display: ${({ $shown }) => ($shown ? "display" : "none")};
   background-color: ${({ theme }) => theme.title?.background};
   color: ${({ theme }) => theme.title?.foreground};
   list-style: none;
@@ -17,7 +17,7 @@ interface Props extends React.HTMLAttributes<HTMLElement> {
 }
 
 const CompletionTitle: React.FC<Props> = ({ shown, title, ...props }) => (
-  <Li shown={Number(shown)} {...props}>
+  <Li $shown={Number(shown)} {...props}>
     {title}
   </Li>
 );

--- a/src/console/completion/components/CompletionTitle.tsx
+++ b/src/console/completion/components/CompletionTitle.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 
 const Li = styled.li<{ $shown: number }>`
-  display: ${({ $shown }) => ($shown ? "display" : "none")};
+  display: ${({ $shown }) => ($shown ? "block" : "none")};
   background-color: ${({ theme }) => theme.title?.background};
   color: ${({ theme }) => theme.title?.foreground};
   list-style: none;


### PR DESCRIPTION
Some warning appears on browser's developer tools when opening console.  Replace some codes with styled-components practices.

 
![screenshot](https://github.com/ueokande/vimmatic/assets/534166/7945b97a-63d6-4764-beef-6115a01711c9)
