### PR TITLE
fix: minify built JavaScript files

### DIFF
--- a/script/build
+++ b/script/build
@@ -24,6 +24,7 @@ const buildScripts = async (browser) => {
     bundle: true,
     target: targets[browser],
     sourcemap: "inline",
+    minify: process.env.NODE_ENV !== "development",
     platform: "browser",
   });
 };


### PR DESCRIPTION
The file size exceeds 4MB without minify.  It reaches a file limitation on AMO.  Minify for a production build.