### PR TITLE
fix: ignore unexpected message

### DIFF
--- a/src/content/client/WindowMessageSender.ts
+++ b/src/content/client/WindowMessageSender.ts
@@ -3,6 +3,13 @@ import type { Key, Schema, Request } from "../../messaging/schema/window";
 
 type WindowMessageSender = SimplexSender<Schema>;
 
+/**
+ * The window.postMessage() is used to identify a frame id of the <iframe>
+ * element through the background script.  Only Firefox supports to get the
+ * frame id of the <iframe> elementa and the other browsers do not support.
+ *
+ * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getFrameId
+ */
 export const newSender = (target: Window) => {
   const sender = new SimplexSender<Schema>((type: Key, args: Request) => {
     const msg = JSON.stringify({ args, type });

--- a/src/content/messaging/WindowMessageListener.ts
+++ b/src/content/messaging/WindowMessageListener.ts
@@ -45,14 +45,11 @@ export default class WindowMessageListener {
       try {
         message = JSON.parse(event.data);
       } catch (e) {
-        // eslint-disable-next-line no-console
-        console.warn("unexpected message format:", e);
+        // ignore unexpected message
         return;
       }
 
       if (typeof message !== "object" && message !== null) {
-        // eslint-disable-next-line no-console
-        console.warn("unexpected message format:", message);
         return;
       }
 
@@ -61,8 +58,7 @@ export default class WindowMessageListener {
         typeof type !== "string" ||
         (typeof args !== "undefined" && typeof args !== "object")
       ) {
-        // eslint-disable-next-line no-console
-        console.warn("unexpected message format:", message);
+        // ignore unexpected message
         return;
       }
 


### PR DESCRIPTION
Ignore unexpected message from `window.postMessage()` on the content script.  The content script can receive messages from other than the add-on, the loaded page or other addons.

close #351 