### PR TITLE
fix: change default value of find mode

### DIFF
--- a/src/background/property/IgnoreCaseProperty.ts
+++ b/src/background/property/IgnoreCaseProperty.ts
@@ -15,7 +15,8 @@ export default class IgnoreCaseProperty implements Property {
   }
 
   defaultValue() {
-    return false;
+    // prefer the browser setting instead of vim's default
+    return true;
   }
 
   validate(value: PropertyType) {

--- a/src/settings/default.ts
+++ b/src/settings/default.ts
@@ -91,7 +91,9 @@ export const defaultJSONSettings = `{
     "hintchars": "abcdefghijklmnopqrstuvwxyz",
     "smoothscroll": false,
     "complete": "sbh",
-    "colorscheme": "system"
+    "colorscheme": "system",
+    "ignorecase": true,
+    "findmode": "normal"
   },
   "blacklist": [
   ],


### PR DESCRIPTION
Change default value of findmode and ignorecase implemented by #349.  It prefers the browser default instead of Vim's default.