### PR TITLE
fix: keep class names

### DIFF
--- a/script/build.mjs
+++ b/script/build.mjs
@@ -22,6 +22,7 @@ const buildScripts = async (browser) => {
     bundle: true,
     target: targets[browser],
     sourcemap: "inline",
+    keepNames: true,
     minify: process.env.NODE_ENV !== "development",
     platform: "browser",
   });


### PR DESCRIPTION
Avoid mangling class names on minification or bundling.  The addon uses the class `name` as a key of the local storage.  The names depends on the build result and key can be changed or conflicted.