### PR TITLE
refactor: replace injection tokens with symbols and use provider module

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "homepage": "https://github.com/ueokande/vimmatic",
   "dependencies": {
     "@abraham/reflection": "^0.12.0",
-    "inversify": "^6.0.1",
+    "inversify": "^6.0.2",
+    "inversify-binding-decorators": "^4.0.0",
     "prismjs": "^1.29.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,11 @@ dependencies:
     specifier: ^0.12.0
     version: 0.12.0
   inversify:
-    specifier: ^6.0.1
-    version: 6.0.1
+    specifier: ^6.0.2
+    version: 6.0.2
+  inversify-binding-decorators:
+    specifier: ^4.0.0
+    version: 4.0.0
   prismjs:
     specifier: ^1.29.0
     version: 1.29.0
@@ -2954,8 +2957,12 @@ packages:
       loose-envify: 1.4.0
     dev: true
 
-  /inversify@6.0.1:
-    resolution: {integrity: sha512-B3ex30927698TJENHR++8FfEaJGqoWOgI6ZY5Ht/nLUsFCwHn6akbwtnUAPCgUepAnTpe2qHxhDNjoKLyz6rgQ==}
+  /inversify-binding-decorators@4.0.0:
+    resolution: {integrity: sha512-r8au/oH3vS7ttHj0RivAznwElySeRohLfg8lvOSzbrX6abf/8ik8ptk49XbzdShgrnalvl7CM6MjcskfM7MMqQ==}
+    dev: false
+
+  /inversify@6.0.2:
+    resolution: {integrity: sha512-i9m8j/7YIv4mDuYXUAcrpKPSaju/CIly9AHK5jvCBeoiM/2KEsuCQTTP+rzSWWpLYWRukdXFSl6ZTk2/uumbiA==}
     dev: false
 
   /ipaddr.js@1.9.1:

--- a/src/background/Application.ts
+++ b/src/background/Application.ts
@@ -2,12 +2,12 @@ import { injectable, inject } from "inversify";
 import { BackgroundMessageListener } from "./messaging/BackgroundMessageListener";
 import { FindPortListener } from "./messaging/FindPortListener";
 import { VersionUseCase } from "./usecases/VersionUseCase";
-import type { FindRepository } from "./repositories/FindRepository";
-import type { ReadyFrameRepository } from "./repositories/ReadyFrameRepository";
+import { FindRepository } from "./repositories/FindRepository";
+import { ReadyFrameRepository } from "./repositories/ReadyFrameRepository";
 import { SettingsEventUseCase } from "./usecases/SettingsEventUseCase";
-import type { FrameClient } from "./clients/FrameClient";
+import { FrameClient } from "./clients/FrameClient";
 import { AddonEnabledEventUseCase } from "./usecases/AddonEnabledEventUseCase";
-import type { LastSelectedTabRepository } from "./repositories/LastSelectedTabRepository";
+import { LastSelectedTabRepository } from "./repositories/LastSelectedTabRepository";
 import { ModeUseCase } from "./usecases/ModeUseCase";
 import { HintModeUseCase } from "./usecases/HintModeUseCase";
 
@@ -18,15 +18,15 @@ export class Application {
     private readonly backgroundMessageListener: BackgroundMessageListener,
     @inject(VersionUseCase)
     private readonly versionUseCase: VersionUseCase,
-    @inject("FindRepository")
+    @inject(FindRepository)
     private readonly findRepository: FindRepository,
-    @inject("ReadyFrameRepository")
+    @inject(ReadyFrameRepository)
     private readonly frameRepository: ReadyFrameRepository,
-    @inject("LastSelectedTabRepository")
+    @inject(LastSelectedTabRepository)
     private readonly lastSelectedTabRepository: LastSelectedTabRepository,
     @inject(SettingsEventUseCase)
     private readonly settingsEventUseCase: SettingsEventUseCase,
-    @inject("FrameClient")
+    @inject(FrameClient)
     private readonly frameClient: FrameClient,
     @inject(AddonEnabledEventUseCase)
     private readonly addonEnabledEventUseCase: AddonEnabledEventUseCase,

--- a/src/background/clients/AddonEnabledClient.ts
+++ b/src/background/clients/AddonEnabledClient.ts
@@ -7,6 +7,8 @@ export interface AddonEnabledClient {
   disable(tabId: number): Promise<void>;
 }
 
+export const AddonEnabledClient = Symbol("AddonEnabledClient");
+
 @injectable()
 export class AddonEnabledClientImpl implements AddonEnabledClient {
   async enable(tabId: number): Promise<void> {

--- a/src/background/clients/AddonEnabledClient.ts
+++ b/src/background/clients/AddonEnabledClient.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { newSender } from "./ContentMessageSender";
 
 export interface AddonEnabledClient {
@@ -9,7 +9,7 @@ export interface AddonEnabledClient {
 
 export const AddonEnabledClient = Symbol("AddonEnabledClient");
 
-@injectable()
+@provide(AddonEnabledClient)
 export class AddonEnabledClientImpl implements AddonEnabledClient {
   async enable(tabId: number): Promise<void> {
     const sender = newSender(tabId);

--- a/src/background/clients/ConsoleClient.ts
+++ b/src/background/clients/ConsoleClient.ts
@@ -13,6 +13,8 @@ export interface ConsoleClient {
   hide(tabId: number): Promise<void>;
 }
 
+export const ConsoleClient = Symbol("ConsoleClient");
+
 @injectable()
 export class ConsoleClientImpl implements ConsoleClient {
   async showCommand(tabId: number, command: string): Promise<void> {

--- a/src/background/clients/ConsoleClient.ts
+++ b/src/background/clients/ConsoleClient.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { newSender } from "./ConsoleMessageSender";
 
 export interface ConsoleClient {
@@ -15,7 +15,7 @@ export interface ConsoleClient {
 
 export const ConsoleClient = Symbol("ConsoleClient");
 
-@injectable()
+@provide(ConsoleClient)
 export class ConsoleClientImpl implements ConsoleClient {
   async showCommand(tabId: number, command: string): Promise<void> {
     const sender = newSender(tabId);

--- a/src/background/clients/ConsoleFrameClient.ts
+++ b/src/background/clients/ConsoleFrameClient.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { newSender } from "./ContentMessageSender";
 
 export interface ConsoleFrameClient {
@@ -7,7 +7,7 @@ export interface ConsoleFrameClient {
 
 export const ConsoleFrameClient = Symbol("ConsoleFrameClient");
 
-@injectable()
+@provide(ConsoleFrameClient)
 export class ConsoleFrameClientImpl implements ConsoleFrameClient {
   async resize(tabId: number, width: number, height: number): Promise<void> {
     const sender = newSender(tabId);

--- a/src/background/clients/ConsoleFrameClient.ts
+++ b/src/background/clients/ConsoleFrameClient.ts
@@ -5,6 +5,8 @@ export interface ConsoleFrameClient {
   resize(tabId: number, width: number, height: number): Promise<void>;
 }
 
+export const ConsoleFrameClient = Symbol("ConsoleFrameClient");
+
 @injectable()
 export class ConsoleFrameClientImpl implements ConsoleFrameClient {
   async resize(tabId: number, width: number, height: number): Promise<void> {

--- a/src/background/clients/ContentMessageClient.ts
+++ b/src/background/clients/ContentMessageClient.ts
@@ -40,6 +40,8 @@ export interface ContentMessageClient {
   focusFirstInput(tabId: number): Promise<void>;
 }
 
+export const ContentMessageClient = Symbol("ContentMessageClient");
+
 @injectable()
 export class ContentMessageClientImpl implements ContentMessageClient {
   async scrollTo(

--- a/src/background/clients/ContentMessageClient.ts
+++ b/src/background/clients/ContentMessageClient.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { newSender } from "./ContentMessageSender";
 
 export interface ContentMessageClient {
@@ -42,7 +42,7 @@ export interface ContentMessageClient {
 
 export const ContentMessageClient = Symbol("ContentMessageClient");
 
-@injectable()
+@provide(ContentMessageClient)
 export class ContentMessageClientImpl implements ContentMessageClient {
   async scrollTo(
     tabId: number,

--- a/src/background/clients/FindClient.ts
+++ b/src/background/clients/FindClient.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { newSender } from "./ContentMessageSender";
 import type { FindQuery } from "../../shared/findQuery";
 
@@ -12,7 +12,7 @@ export interface FindClient {
 
 export const FindClient = Symbol("FindClient");
 
-@injectable()
+@provide(FindClient)
 export class FindClientImpl implements FindClient {
   async findNext(
     tabId: number,

--- a/src/background/clients/FindClient.ts
+++ b/src/background/clients/FindClient.ts
@@ -10,6 +10,8 @@ export interface FindClient {
   clearSelection(tabId: number, frameId: number): Promise<void>;
 }
 
+export const FindClient = Symbol("FindClient");
+
 @injectable()
 export class FindClientImpl implements FindClient {
   async findNext(

--- a/src/background/clients/FrameClient.ts
+++ b/src/background/clients/FrameClient.ts
@@ -5,6 +5,8 @@ export interface FrameClient {
   notifyFrameId(tabId: number, frameId: number): Promise<void>;
 }
 
+export const FrameClient = Symbol("FrameClient");
+
 @injectable()
 export class FrameClientImpl implements FrameClient {
   async notifyFrameId(tabId: number, frameId: number): Promise<void> {

--- a/src/background/clients/FrameClient.ts
+++ b/src/background/clients/FrameClient.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { newSender } from "./ContentMessageSender";
 
 export interface FrameClient {
@@ -7,7 +7,7 @@ export interface FrameClient {
 
 export const FrameClient = Symbol("FrameClient");
 
-@injectable()
+@provide(FrameClient)
 export class FrameClientImpl implements FrameClient {
   async notifyFrameId(tabId: number, frameId: number): Promise<void> {
     const sender = newSender(tabId, frameId);

--- a/src/background/clients/HintClient.ts
+++ b/src/background/clients/HintClient.ts
@@ -42,6 +42,8 @@ export interface HintClient {
   clickElement(tabId: number, frameId: number, element: string): Promise<void>;
 }
 
+export const HintClient = Symbol("HintClient");
+
 @injectable()
 export class HintClientImpl implements HintClient {
   async lookupTargets(

--- a/src/background/clients/HintClient.ts
+++ b/src/background/clients/HintClient.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { newSender } from "./ContentMessageSender";
 import type { HTMLElementType } from "../../shared/HTMLElementType";
 
@@ -44,7 +44,7 @@ export interface HintClient {
 
 export const HintClient = Symbol("HintClient");
 
-@injectable()
+@provide(HintClient)
 export class HintClientImpl implements HintClient {
   async lookupTargets(
     tabId: number,

--- a/src/background/clients/ModeClient.ts
+++ b/src/background/clients/ModeClient.ts
@@ -6,6 +6,8 @@ export interface ModeClient {
   setMode(tabid: number, mode: Mode): Promise<void>;
 }
 
+export const ModeClient = Symbol("ModeClient");
+
 @injectable()
 export class ModeClientImpl implements ModeClient {
   async setMode(tabId: number, mode: Mode): Promise<void> {

--- a/src/background/clients/ModeClient.ts
+++ b/src/background/clients/ModeClient.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { newSender } from "./ContentMessageSender";
 import type { Mode } from "../../shared/mode";
 
@@ -8,7 +8,7 @@ export interface ModeClient {
 
 export const ModeClient = Symbol("ModeClient");
 
-@injectable()
+@provide(ModeClient)
 export class ModeClientImpl implements ModeClient {
   async setMode(tabId: number, mode: Mode): Promise<void> {
     const sender = newSender(tabId);

--- a/src/background/clients/NavigateClient.ts
+++ b/src/background/clients/NavigateClient.ts
@@ -11,6 +11,8 @@ export interface NavigateClient {
   linkPrev(tabId: number): Promise<void>;
 }
 
+export const NavigateClient = Symbol("NavigateClient");
+
 @injectable()
 export class NavigateClientImpl implements NavigateClient {
   async historyNext(tabId: number): Promise<void> {

--- a/src/background/clients/NavigateClient.ts
+++ b/src/background/clients/NavigateClient.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { newSender } from "./ContentMessageSender";
 
 export interface NavigateClient {
@@ -13,7 +13,7 @@ export interface NavigateClient {
 
 export const NavigateClient = Symbol("NavigateClient");
 
-@injectable()
+@provide(NavigateClient)
 export class NavigateClientImpl implements NavigateClient {
   async historyNext(tabId: number): Promise<void> {
     const sender = newSender(tabId);

--- a/src/background/clients/TopFrameClient.ts
+++ b/src/background/clients/TopFrameClient.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { newSender } from "./ContentMessageSender";
 
 export type Rect = {
@@ -19,7 +19,7 @@ export interface TopFrameClient {
 
 export const TopFrameClient = Symbol("TopFrameClient");
 
-@injectable()
+@provide(TopFrameClient)
 export class TopFrameClientImpl implements TopFrameClient {
   getWindowViewport(tabId: number): Promise<Rect> {
     const sender = newSender(tabId, 0);

--- a/src/background/clients/TopFrameClient.ts
+++ b/src/background/clients/TopFrameClient.ts
@@ -17,6 +17,8 @@ export interface TopFrameClient {
   getFramePosition(tabId: number, frameId: number): Promise<Point | undefined>;
 }
 
+export const TopFrameClient = Symbol("TopFrameClient");
+
 @injectable()
 export class TopFrameClientImpl implements TopFrameClient {
   getWindowViewport(tabId: number): Promise<Rect> {

--- a/src/background/command/CommandRegistry.ts
+++ b/src/background/command/CommandRegistry.ts
@@ -8,6 +8,8 @@ export interface CommandRegistry {
   getCommands(): Command[];
 }
 
+export const CommandRegistry = Symbol("CommandRegistry");
+
 export class CommandRegistryImpl implements CommandRegistry {
   private readonly commands: Command[] = [];
   private readonly commandNames: Map<string, Command> = new Map();

--- a/src/background/command/index.ts
+++ b/src/background/command/index.ts
@@ -11,32 +11,29 @@ import { SetCommand } from "./SetCommand";
 import { TabOpenCommand } from "./TabOpenCommand";
 import { WindowOpenCommand } from "./WindowOpenCommand";
 import { BufferCommandHelper } from "./BufferCommandHelper";
-import type { PropertyRegistry } from "../property/PropertyRegistry";
-import type { PropertySettings } from "../settings/PropertySettings";
-import type { SearchEngineSettings } from "../settings/SearchEngineSettings";
+import { PropertyRegistry } from "../property/PropertyRegistry";
+import { PropertySettings } from "../settings/PropertySettings";
+import { SearchEngineSettings } from "../settings/SearchEngineSettings";
 import { type CommandRegistry, CommandRegistryImpl } from "./CommandRegistry";
-import type { LastSelectedTabRepository } from "../repositories/LastSelectedTabRepository";
-import type { ConsoleClient } from "../clients/ConsoleClient";
+import { LastSelectedTabRepository } from "../repositories/LastSelectedTabRepository";
+import { ConsoleClient } from "../clients/ConsoleClient";
 
 @injectable()
 export class CommandRegistryFactory {
-  private readonly propertyRegistry: PropertyRegistry;
-
   private readonly bufferCommandHelper: BufferCommandHelper;
 
   constructor(
-    @inject("PropertyRegistry")
-    propertyRegistry: PropertyRegistry,
-    @inject("ConsoleClient")
+    @inject(PropertyRegistry)
+    private readonly propertyRegistry: PropertyRegistry,
+    @inject(ConsoleClient)
     private readonly consoleClient: ConsoleClient,
-    @inject("PropertySettings")
+    @inject(PropertySettings)
     private readonly propertySettings: PropertySettings,
-    @inject("SearchEngineSettings")
+    @inject(SearchEngineSettings)
     private readonly searchEngineSettings: SearchEngineSettings,
-    @inject("LastSelectedTabRepository")
+    @inject(LastSelectedTabRepository)
     private readonly lastSelectedTabRepository: LastSelectedTabRepository,
   ) {
-    this.propertyRegistry = propertyRegistry;
     this.bufferCommandHelper = new BufferCommandHelper(
       this.lastSelectedTabRepository,
     );

--- a/src/background/di.ts
+++ b/src/background/di.ts
@@ -1,116 +1,55 @@
 /* eslint-disable max-len */
 
 import { Container } from "inversify";
-import {
-  LastSelectedTabRepository,
-  LastSelectedTabRepositoryImpl,
-} from "./repositories/LastSelectedTabRepository";
-import { Notifier, NotifierImpl } from "./presenters/Notifier";
-import {
-  ContentMessageClient,
-  ContentMessageClientImpl,
-} from "./clients/ContentMessageClient";
-import { NavigateClient, NavigateClientImpl } from "./clients/NavigateClient";
-import { ConsoleClient, ConsoleClientImpl } from "./clients/ConsoleClient";
+import { buildProviderModule } from "inversify-binding-decorators";
 import {
   BrowserSettingRepository,
   FirefoxBrowserSettingRepositoryImpl,
   ChromeBrowserSettingRepositoryImpl,
 } from "./repositories/BrowserSettingRepository";
 import {
-  RepeatRepository,
-  RepeatRepositoryImpl,
-} from "./repositories/RepeatRepository";
-import { FindClient, FindClientImpl } from "./clients/FindClient";
-import {
-  ConsoleFrameClient,
-  ConsoleFrameClientImpl,
-} from "./clients/ConsoleFrameClient";
-import {
-  FindRepository,
-  FindRepositoryImpl,
-} from "./repositories/FindRepository";
-import {
-  FindHistoryRepository,
-  FindHistoryRepositoryImpl,
-} from "./repositories/FindHistoryRepository";
-import {
-  ReadyFrameRepository,
-  ReadyFrameRepositoryImpl,
-} from "./repositories/ReadyFrameRepository";
-import {
   ClipboardRepository,
   FirefoxClipboardRepositoryImpl,
   ChromeClipboardRepositoryImpl,
 } from "./repositories/ClipboardRepository";
-import {
-  PropertySettings,
-  PropertySettingsImpl,
-} from "./settings/PropertySettings";
-import { StyleSettings, StyleSettingsImpl } from "./settings/StyleSettings";
-import {
-  SearchEngineSettings,
-  SearchEngineSettingsImpl,
-} from "./settings/SearchEngineSettings";
-import {
-  ModeRepository,
-  ModeRepositoryImpl,
-} from "./repositories/ModeRepository";
-import {
-  SettingsRepository,
-  PermanentSettingsRepository,
-  TransientSettingsRepositoryImpl,
-  PermanentSettingsRepositoryImpl,
-} from "./settings/SettingsRepository";
-import { ModeClient, ModeClientImpl } from "./clients/ModeClient";
-import {
-  MarkRepository,
-  MarkRepositoryImpl,
-} from "./repositories/MarkRepository";
-import { HintClient, HintClientImpl } from "./clients/HintClient";
-import {
-  HintRepository,
-  HintRepositoryImpl,
-} from "./repositories/HintRepository";
-import { FrameClient, FrameClientImpl } from "./clients/FrameClient";
-import { TopFrameClient, TopFrameClientImpl } from "./clients/TopFrameClient";
-import {
-  AddonEnabledRepository,
-  AddonEnabledRepositoryImpl,
-} from "./repositories/AddonEnabledRepository";
-import {
-  AddonEnabledClient,
-  AddonEnabledClientImpl,
-} from "./clients/AddonEnabledClient";
-import {
-  ToolbarPresenter,
-  ToolbarPresenterImpl,
-} from "./presenters/ToolbarPresenter";
-import { TabPresenter, TabPresenterImpl } from "./presenters/TabPresenter";
 import { createPropertyRegistry } from "./property";
-import { PropertyRegistry } from "./property/PropertyRegistry";
 import { CommandRegistryFactory } from "./command";
 import { CommandRegistry } from "./command/CommandRegistry";
 import { OperatorRegistryFactory } from "./operators";
 import { OperatorRegistry } from "./operators/OperatorRegistry";
-import {
-  HintActionFactory,
-  HintActionFactoryImpl,
-} from "./hint/HintActionFactory";
+import { PropertyRegistry } from "./property/PropertyRegistry";
+import "./clients/AddonEnabledClient";
+import "./clients/ConsoleClient";
+import "./clients/ConsoleFrameClient";
+import "./clients/ContentMessageClient";
+import "./clients/FindClient";
+import "./clients/FrameClient";
+import "./clients/HintClient";
+import "./clients/ModeClient";
+import "./clients/NavigateClient";
+import "./clients/TopFrameClient";
+import "./hint/HintActionFactory";
+import "./presenters/Notifier";
+import "./presenters/TabPresenter";
+import "./presenters/ToolbarPresenter";
+import "./repositories/AddonEnabledRepository";
+import "./repositories/FindHistoryRepository";
+import "./repositories/FindRepository";
+import "./repositories/HintRepository";
+import "./repositories/LastSelectedTabRepository";
+import "./repositories/MarkRepository";
+import "./repositories/ModeRepository";
+import "./repositories/ReadyFrameRepository";
+import "./repositories/RepeatRepository";
+import "./settings/PropertySettings";
+import "./settings/SearchEngineSettings";
+import "./settings/SettingsRepository";
+import "./settings/StyleSettings";
 
 const container = new Container({ autoBindInjectable: true });
 
-container.bind(LastSelectedTabRepository).to(LastSelectedTabRepositoryImpl);
-container.bind(Notifier).to(NotifierImpl);
-container.bind(RepeatRepository).to(RepeatRepositoryImpl);
-container.bind(FindRepository).to(FindRepositoryImpl);
-container.bind(FindHistoryRepository).to(FindHistoryRepositoryImpl);
-container.bind(FindClient).to(FindClientImpl);
-container.bind(ContentMessageClient).to(ContentMessageClientImpl);
-container.bind(NavigateClient).to(NavigateClientImpl);
-container.bind(ConsoleClient).to(ConsoleClientImpl);
-container.bind(ConsoleFrameClient).to(ConsoleFrameClientImpl);
-container.bind(ReadyFrameRepository).to(ReadyFrameRepositoryImpl);
+container.load(buildProviderModule());
+
 if (process.env.BROWSER === "firefox") {
   container.bind(ClipboardRepository).to(FirefoxClipboardRepositoryImpl);
   container
@@ -122,23 +61,6 @@ if (process.env.BROWSER === "firefox") {
     .bind(BrowserSettingRepository)
     .to(ChromeBrowserSettingRepositoryImpl);
 }
-container.bind(PropertySettings).to(PropertySettingsImpl);
-container.bind(StyleSettings).to(StyleSettingsImpl);
-container.bind(SearchEngineSettings).to(SearchEngineSettingsImpl);
-container.bind(ModeRepository).to(ModeRepositoryImpl);
-container.bind(MarkRepository).to(MarkRepositoryImpl);
-container.bind(ModeClient).to(ModeClientImpl);
-container.bind(HintClient).to(HintClientImpl);
-container.bind(HintRepository).to(HintRepositoryImpl);
-container.bind(FrameClient).to(FrameClientImpl);
-container.bind(TopFrameClient).to(TopFrameClientImpl);
-container.bind(AddonEnabledRepository).to(AddonEnabledRepositoryImpl);
-container.bind(AddonEnabledClient).to(AddonEnabledClientImpl);
-container.bind(ToolbarPresenter).to(ToolbarPresenterImpl);
-container.bind(TabPresenter).to(TabPresenterImpl);
-container.bind(PermanentSettingsRepository).to(PermanentSettingsRepositoryImpl);
-container.bind(SettingsRepository).to(TransientSettingsRepositoryImpl);
-container.bind(HintActionFactory).to(HintActionFactoryImpl);
 container.bind(PropertyRegistry).toConstantValue(createPropertyRegistry());
 container
   .bind(CommandRegistry)

--- a/src/background/di.ts
+++ b/src/background/di.ts
@@ -1,95 +1,150 @@
 /* eslint-disable max-len */
 
 import { Container } from "inversify";
-import { LastSelectedTabRepositoryImpl } from "./repositories/LastSelectedTabRepository";
-import { NotifierImpl } from "./presenters/Notifier";
-import { ContentMessageClientImpl } from "./clients/ContentMessageClient";
-import { NavigateClientImpl } from "./clients/NavigateClient";
-import { ConsoleClientImpl } from "./clients/ConsoleClient";
 import {
+  LastSelectedTabRepository,
+  LastSelectedTabRepositoryImpl,
+} from "./repositories/LastSelectedTabRepository";
+import { Notifier, NotifierImpl } from "./presenters/Notifier";
+import {
+  ContentMessageClient,
+  ContentMessageClientImpl,
+} from "./clients/ContentMessageClient";
+import { NavigateClient, NavigateClientImpl } from "./clients/NavigateClient";
+import { ConsoleClient, ConsoleClientImpl } from "./clients/ConsoleClient";
+import {
+  BrowserSettingRepository,
   FirefoxBrowserSettingRepositoryImpl,
   ChromeBrowserSettingRepositoryImpl,
 } from "./repositories/BrowserSettingRepository";
-import { RepeatRepositoryImpl } from "./repositories/RepeatRepository";
-import { FindClientImpl } from "./clients/FindClient";
-import { ConsoleFrameClientImpl } from "./clients/ConsoleFrameClient";
-import { FindRepositoryImpl } from "./repositories/FindRepository";
-import { FindHistoryRepositoryImpl } from "./repositories/FindHistoryRepository";
-import { ReadyFrameRepositoryImpl } from "./repositories/ReadyFrameRepository";
 import {
+  RepeatRepository,
+  RepeatRepositoryImpl,
+} from "./repositories/RepeatRepository";
+import { FindClient, FindClientImpl } from "./clients/FindClient";
+import {
+  ConsoleFrameClient,
+  ConsoleFrameClientImpl,
+} from "./clients/ConsoleFrameClient";
+import {
+  FindRepository,
+  FindRepositoryImpl,
+} from "./repositories/FindRepository";
+import {
+  FindHistoryRepository,
+  FindHistoryRepositoryImpl,
+} from "./repositories/FindHistoryRepository";
+import {
+  ReadyFrameRepository,
+  ReadyFrameRepositoryImpl,
+} from "./repositories/ReadyFrameRepository";
+import {
+  ClipboardRepository,
   FirefoxClipboardRepositoryImpl,
   ChromeClipboardRepositoryImpl,
 } from "./repositories/ClipboardRepository";
-import { PropertySettingsImpl } from "./settings/PropertySettings";
-import { StyleSettingsImpl } from "./settings/StyleSettings";
-import { SearchEngineSettingsImpl } from "./settings/SearchEngineSettings";
-import { ModeRepositoryImpl } from "./repositories/ModeRepository";
 import {
-  TransientSettingsRepository,
+  PropertySettings,
+  PropertySettingsImpl,
+} from "./settings/PropertySettings";
+import { StyleSettings, StyleSettingsImpl } from "./settings/StyleSettings";
+import {
+  SearchEngineSettings,
+  SearchEngineSettingsImpl,
+} from "./settings/SearchEngineSettings";
+import {
+  ModeRepository,
+  ModeRepositoryImpl,
+} from "./repositories/ModeRepository";
+import {
+  SettingsRepository,
   PermanentSettingsRepository,
+  TransientSettingsRepositoryImpl,
+  PermanentSettingsRepositoryImpl,
 } from "./settings/SettingsRepository";
-import { ModeClientImpl } from "./clients/ModeClient";
-import { MarkRepositoryImpl } from "./repositories/MarkRepository";
-import { HintClientImpl } from "./clients/HintClient";
-import { HintRepositoryImpl } from "./repositories/HintRepository";
-import { FrameClientImpl } from "./clients/FrameClient";
-import { TopFrameClientImpl } from "./clients/TopFrameClient";
-import { AddonEnabledRepositoryImpl } from "./repositories/AddonEnabledRepository";
-import { AddonEnabledClientImpl } from "./clients/AddonEnabledClient";
-import { ToolbarPresenterImpl } from "./presenters/ToolbarPresenter";
-import { TabPresenterImpl } from "./presenters/TabPresenter";
+import { ModeClient, ModeClientImpl } from "./clients/ModeClient";
+import {
+  MarkRepository,
+  MarkRepositoryImpl,
+} from "./repositories/MarkRepository";
+import { HintClient, HintClientImpl } from "./clients/HintClient";
+import {
+  HintRepository,
+  HintRepositoryImpl,
+} from "./repositories/HintRepository";
+import { FrameClient, FrameClientImpl } from "./clients/FrameClient";
+import { TopFrameClient, TopFrameClientImpl } from "./clients/TopFrameClient";
+import {
+  AddonEnabledRepository,
+  AddonEnabledRepositoryImpl,
+} from "./repositories/AddonEnabledRepository";
+import {
+  AddonEnabledClient,
+  AddonEnabledClientImpl,
+} from "./clients/AddonEnabledClient";
+import {
+  ToolbarPresenter,
+  ToolbarPresenterImpl,
+} from "./presenters/ToolbarPresenter";
+import { TabPresenter, TabPresenterImpl } from "./presenters/TabPresenter";
 import { createPropertyRegistry } from "./property";
+import { PropertyRegistry } from "./property/PropertyRegistry";
 import { CommandRegistryFactory } from "./command";
-import { OperatorRegistoryFactory } from "./operators";
-import { HintActionFactoryImpl } from "./hint/HintActionFactory";
+import { CommandRegistry } from "./command/CommandRegistry";
+import { OperatorRegistryFactory } from "./operators";
+import { OperatorRegistry } from "./operators/OperatorRegistry";
+import {
+  HintActionFactory,
+  HintActionFactoryImpl,
+} from "./hint/HintActionFactory";
 
 const container = new Container({ autoBindInjectable: true });
 
-container.bind("LastSelectedTabRepository").to(LastSelectedTabRepositoryImpl);
-container.bind("Notifier").to(NotifierImpl);
-container.bind("RepeatRepository").to(RepeatRepositoryImpl);
-container.bind("FindRepository").to(FindRepositoryImpl);
-container.bind("FindHistoryRepository").to(FindHistoryRepositoryImpl);
-container.bind("FindClient").to(FindClientImpl);
-container.bind("ContentMessageClient").to(ContentMessageClientImpl);
-container.bind("NavigateClient").to(NavigateClientImpl);
-container.bind("ConsoleClient").to(ConsoleClientImpl);
-container.bind("ConsoleFrameClient").to(ConsoleFrameClientImpl);
-container.bind("ReadyFrameRepository").to(ReadyFrameRepositoryImpl);
+container.bind(LastSelectedTabRepository).to(LastSelectedTabRepositoryImpl);
+container.bind(Notifier).to(NotifierImpl);
+container.bind(RepeatRepository).to(RepeatRepositoryImpl);
+container.bind(FindRepository).to(FindRepositoryImpl);
+container.bind(FindHistoryRepository).to(FindHistoryRepositoryImpl);
+container.bind(FindClient).to(FindClientImpl);
+container.bind(ContentMessageClient).to(ContentMessageClientImpl);
+container.bind(NavigateClient).to(NavigateClientImpl);
+container.bind(ConsoleClient).to(ConsoleClientImpl);
+container.bind(ConsoleFrameClient).to(ConsoleFrameClientImpl);
+container.bind(ReadyFrameRepository).to(ReadyFrameRepositoryImpl);
 if (process.env.BROWSER === "firefox") {
-  container.bind("ClipboardRepository").to(FirefoxClipboardRepositoryImpl);
+  container.bind(ClipboardRepository).to(FirefoxClipboardRepositoryImpl);
   container
-    .bind("BrowserSettingRepository")
+    .bind(BrowserSettingRepository)
     .to(FirefoxBrowserSettingRepositoryImpl);
 } else {
-  container.bind("ClipboardRepository").to(ChromeClipboardRepositoryImpl);
+  container.bind(ClipboardRepository).to(ChromeClipboardRepositoryImpl);
   container
-    .bind("BrowserSettingRepository")
+    .bind(BrowserSettingRepository)
     .to(ChromeBrowserSettingRepositoryImpl);
 }
-container.bind("PropertySettings").to(PropertySettingsImpl);
-container.bind("StyleSettings").to(StyleSettingsImpl);
-container.bind("SearchEngineSettings").to(SearchEngineSettingsImpl);
-container.bind("ModeRepository").to(ModeRepositoryImpl);
-container.bind("MarkRepository").to(MarkRepositoryImpl);
-container.bind("ModeClient").to(ModeClientImpl);
-container.bind("HintClient").to(HintClientImpl);
-container.bind("HintRepository").to(HintRepositoryImpl);
-container.bind("FrameClient").to(FrameClientImpl);
-container.bind("TopFrameClient").to(TopFrameClientImpl);
-container.bind("AddonEnabledRepository").to(AddonEnabledRepositoryImpl);
-container.bind("AddonEnabledClient").to(AddonEnabledClientImpl);
-container.bind("ToolbarPresenter").to(ToolbarPresenterImpl);
-container.bind("TabPresenter").to(TabPresenterImpl);
-container.bind("PermanentSettingsRepository").to(PermanentSettingsRepository);
-container.bind("SettingsRepository").to(TransientSettingsRepository);
-container.bind("HintActionFactory").to(HintActionFactoryImpl);
-container.bind("PropertyRegistry").toConstantValue(createPropertyRegistry());
+container.bind(PropertySettings).to(PropertySettingsImpl);
+container.bind(StyleSettings).to(StyleSettingsImpl);
+container.bind(SearchEngineSettings).to(SearchEngineSettingsImpl);
+container.bind(ModeRepository).to(ModeRepositoryImpl);
+container.bind(MarkRepository).to(MarkRepositoryImpl);
+container.bind(ModeClient).to(ModeClientImpl);
+container.bind(HintClient).to(HintClientImpl);
+container.bind(HintRepository).to(HintRepositoryImpl);
+container.bind(FrameClient).to(FrameClientImpl);
+container.bind(TopFrameClient).to(TopFrameClientImpl);
+container.bind(AddonEnabledRepository).to(AddonEnabledRepositoryImpl);
+container.bind(AddonEnabledClient).to(AddonEnabledClientImpl);
+container.bind(ToolbarPresenter).to(ToolbarPresenterImpl);
+container.bind(TabPresenter).to(TabPresenterImpl);
+container.bind(PermanentSettingsRepository).to(PermanentSettingsRepositoryImpl);
+container.bind(SettingsRepository).to(TransientSettingsRepositoryImpl);
+container.bind(HintActionFactory).to(HintActionFactoryImpl);
+container.bind(PropertyRegistry).toConstantValue(createPropertyRegistry());
 container
-  .bind("CommandRegistry")
+  .bind(CommandRegistry)
   .toConstantValue(container.resolve(CommandRegistryFactory).create());
 container
-  .bind("OperatorRegistory")
-  .toConstantValue(container.resolve(OperatorRegistoryFactory).create());
+  .bind(OperatorRegistry)
+  .toConstantValue(container.resolve(OperatorRegistryFactory).create());
 
 export { container };

--- a/src/background/hint/HintActionFactory.ts
+++ b/src/background/hint/HintActionFactory.ts
@@ -1,4 +1,5 @@
-import { injectable, inject } from "inversify";
+import { inject } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { QuickHintAction } from "./QuickHintAction";
 import { OpenImageHintAction } from "./OpenImageHintAction";
 import { YankURLHintAction } from "./YankURLHintAction";
@@ -18,7 +19,7 @@ export interface HintActionFactory {
 
 export const HintActionFactory = Symbol("HintActionFactory");
 
-@injectable()
+@provide(HintActionFactory)
 export class HintActionFactoryImpl implements HintActionFactory {
   constructor(
     @inject(QuickHintAction)

--- a/src/background/hint/HintActionFactory.ts
+++ b/src/background/hint/HintActionFactory.ts
@@ -16,6 +16,8 @@ export interface HintActionFactory {
   createHintAction(name: string): HintAction;
 }
 
+export const HintActionFactory = Symbol("HintActionFactory");
+
 @injectable()
 export class HintActionFactoryImpl implements HintActionFactory {
   constructor(

--- a/src/background/hint/OpenCommandHintAction.ts
+++ b/src/background/hint/OpenCommandHintAction.ts
@@ -1,14 +1,14 @@
 import { injectable, inject } from "inversify";
-import type { HintClient } from "../clients/HintClient";
+import { HintClient } from "../clients/HintClient";
 import type { HintTarget, HintAction } from "./types";
-import type { ConsoleClient } from "../clients/ConsoleClient";
+import { ConsoleClient } from "../clients/ConsoleClient";
 
 @injectable()
 export class OpenCommandHintAction implements HintAction {
   constructor(
-    @inject("HintClient")
+    @inject(HintClient)
     private readonly hintClient: HintClient,
-    @inject("ConsoleClient")
+    @inject(ConsoleClient)
     private readonly consoleClient: ConsoleClient,
   ) {}
 

--- a/src/background/hint/OpenHintAction.ts
+++ b/src/background/hint/OpenHintAction.ts
@@ -1,14 +1,14 @@
 import { injectable, inject } from "inversify";
-import type { HintClient } from "../clients/HintClient";
+import { HintClient } from "../clients/HintClient";
 import type { HintTarget, HintAction } from "./types";
-import type { TabPresenter } from "../presenters/TabPresenter";
+import { TabPresenter } from "../presenters/TabPresenter";
 
 @injectable()
 export class OpenHintAction implements HintAction {
   constructor(
-    @inject("HintClient")
+    @inject(HintClient)
     private readonly hintClient: HintClient,
-    @inject("TabPresenter")
+    @inject(TabPresenter)
     private readonly tabPresenter: TabPresenter,
   ) {}
 

--- a/src/background/hint/OpenImageHintAction.ts
+++ b/src/background/hint/OpenImageHintAction.ts
@@ -1,14 +1,14 @@
 import { injectable, inject } from "inversify";
-import type { HintClient } from "../clients/HintClient";
+import { HintClient } from "../clients/HintClient";
 import type { HintTarget, HintAction } from "./types";
-import type { TabPresenter } from "../presenters/TabPresenter";
+import { TabPresenter } from "../presenters/TabPresenter";
 
 @injectable()
 export class OpenImageHintAction implements HintAction {
   constructor(
-    @inject("HintClient")
+    @inject(HintClient)
     private readonly hintClient: HintClient,
-    @inject("TabPresenter")
+    @inject(TabPresenter)
     private readonly tabPresenter: TabPresenter,
   ) {}
 

--- a/src/background/hint/OpenSourceHintAction.ts
+++ b/src/background/hint/OpenSourceHintAction.ts
@@ -1,14 +1,14 @@
 import { injectable, inject } from "inversify";
-import type { HintClient } from "../clients/HintClient";
+import { HintClient } from "../clients/HintClient";
 import type { HintTarget, HintAction } from "./types";
-import type { TabPresenter } from "../presenters/TabPresenter";
+import { TabPresenter } from "../presenters/TabPresenter";
 
 @injectable()
 export class OpenSourceHintAction implements HintAction {
   constructor(
-    @inject("HintClient")
+    @inject(HintClient)
     private readonly hintClient: HintClient,
-    @inject("TabPresenter")
+    @inject(TabPresenter)
     private readonly tabPresenter: TabPresenter,
   ) {}
 

--- a/src/background/hint/QuickHintAction.ts
+++ b/src/background/hint/QuickHintAction.ts
@@ -1,15 +1,15 @@
 import { injectable, inject } from "inversify";
-import type { HintClient } from "../clients/HintClient";
+import { HintClient } from "../clients/HintClient";
 import type { HTMLElementType } from "../../shared/HTMLElementType";
-import type { TabPresenter } from "../presenters/TabPresenter";
+import { TabPresenter } from "../presenters/TabPresenter";
 import type { HintTarget, HintAction } from "./types";
 
 @injectable()
 export class QuickHintAction implements HintAction {
   constructor(
-    @inject("HintClient")
+    @inject(HintClient)
     private readonly hintClient: HintClient,
-    @inject("TabPresenter")
+    @inject(TabPresenter)
     private readonly tabPresenter: TabPresenter,
   ) {}
 

--- a/src/background/hint/TabopenCommandHintAction.ts
+++ b/src/background/hint/TabopenCommandHintAction.ts
@@ -1,14 +1,14 @@
 import { injectable, inject } from "inversify";
-import type { HintClient } from "../clients/HintClient";
+import { HintClient } from "../clients/HintClient";
 import type { HintTarget, HintAction } from "./types";
-import type { ConsoleClient } from "../clients/ConsoleClient";
+import { ConsoleClient } from "../clients/ConsoleClient";
 
 @injectable()
 export class TabopenCommandHintAction implements HintAction {
   constructor(
-    @inject("HintClient")
+    @inject(HintClient)
     private readonly hintClient: HintClient,
-    @inject("ConsoleClient")
+    @inject(ConsoleClient)
     private readonly consoleClient: ConsoleClient,
   ) {}
 

--- a/src/background/hint/TabopenHintAction.ts
+++ b/src/background/hint/TabopenHintAction.ts
@@ -1,14 +1,14 @@
 import { injectable, inject } from "inversify";
-import type { HintClient } from "../clients/HintClient";
+import { HintClient } from "../clients/HintClient";
 import type { HintTarget, HintAction } from "./types";
-import type { TabPresenter } from "../presenters/TabPresenter";
+import { TabPresenter } from "../presenters/TabPresenter";
 
 @injectable()
 export class TabopenHintAction implements HintAction {
   constructor(
-    @inject("HintClient")
+    @inject(HintClient)
     private readonly hintClient: HintClient,
-    @inject("TabPresenter")
+    @inject(TabPresenter)
     private readonly tabPresenter: TabPresenter,
   ) {}
 

--- a/src/background/hint/WinopenCommandHintAction.ts
+++ b/src/background/hint/WinopenCommandHintAction.ts
@@ -1,14 +1,14 @@
 import { injectable, inject } from "inversify";
-import type { HintClient } from "../clients/HintClient";
+import { HintClient } from "../clients/HintClient";
 import type { HintTarget, HintAction } from "./types";
-import type { ConsoleClient } from "../clients/ConsoleClient";
+import { ConsoleClient } from "../clients/ConsoleClient";
 
 @injectable()
 export class WinopenCommandHintAction implements HintAction {
   constructor(
-    @inject("HintClient")
+    @inject(HintClient)
     private readonly hintClient: HintClient,
-    @inject("ConsoleClient")
+    @inject(ConsoleClient)
     private readonly consoleClient: ConsoleClient,
   ) {}
 

--- a/src/background/hint/WinopenHintAction.ts
+++ b/src/background/hint/WinopenHintAction.ts
@@ -1,14 +1,14 @@
 import { injectable, inject } from "inversify";
-import type { HintClient } from "../clients/HintClient";
+import { HintClient } from "../clients/HintClient";
 import type { HintTarget, HintAction } from "./types";
-import type { TabPresenter } from "../presenters/TabPresenter";
+import { TabPresenter } from "../presenters/TabPresenter";
 
 @injectable()
 export class WinopenHintAction implements HintAction {
   constructor(
-    @inject("HintClient")
+    @inject(HintClient)
     private readonly hintClient: HintClient,
-    @inject("TabPresenter")
+    @inject(TabPresenter)
     private readonly tabPresenter: TabPresenter,
   ) {}
 

--- a/src/background/hint/YankLinkTextHintAction.ts
+++ b/src/background/hint/YankLinkTextHintAction.ts
@@ -1,17 +1,17 @@
 import { injectable, inject } from "inversify";
-import type { HintClient } from "../clients/HintClient";
+import { HintClient } from "../clients/HintClient";
 import type { HintTarget, HintAction } from "./types";
-import type { ClipboardRepository } from "../repositories/ClipboardRepository";
-import type { ConsoleClient } from "../clients/ConsoleClient";
+import { ClipboardRepository } from "../repositories/ClipboardRepository";
+import { ConsoleClient } from "../clients/ConsoleClient";
 
 @injectable()
 export class YankLinkTextHintAction implements HintAction {
   constructor(
-    @inject("HintClient")
+    @inject(HintClient)
     private readonly hintClient: HintClient,
-    @inject("ClipboardRepository")
+    @inject(ClipboardRepository)
     private readonly clipboardRepository: ClipboardRepository,
-    @inject("ConsoleClient")
+    @inject(ConsoleClient)
     private readonly consoleClient: ConsoleClient,
   ) {}
 

--- a/src/background/hint/YankURLHintAction.ts
+++ b/src/background/hint/YankURLHintAction.ts
@@ -1,17 +1,17 @@
 import { injectable, inject } from "inversify";
-import type { HintClient } from "../clients/HintClient";
+import { HintClient } from "../clients/HintClient";
 import type { HintTarget, HintAction } from "./types";
-import type { ClipboardRepository } from "../repositories/ClipboardRepository";
-import type { ConsoleClient } from "../clients/ConsoleClient";
+import { ClipboardRepository } from "../repositories/ClipboardRepository";
+import { ConsoleClient } from "../clients/ConsoleClient";
 
 @injectable()
 export class YankURLHintAction implements HintAction {
   constructor(
-    @inject("HintClient")
+    @inject(HintClient)
     private readonly hintClient: HintClient,
-    @inject("ClipboardRepository")
+    @inject(ClipboardRepository)
     private readonly clipboardRepository: ClipboardRepository,
-    @inject("ConsoleClient")
+    @inject(ConsoleClient)
     private readonly consoleClient: ConsoleClient,
   ) {}
 

--- a/src/background/messaging/BackgroundMessageListener.ts
+++ b/src/background/messaging/BackgroundMessageListener.ts
@@ -5,7 +5,7 @@ import { OperationController } from "../controllers/OperationController";
 import { KeyController } from "../controllers/KeyController";
 import { ConsoleController } from "../controllers/ConsoleController";
 import { FindController } from "../controllers/FindController";
-import type { ConsoleClient } from "../clients/ConsoleClient";
+import { ConsoleClient } from "../clients/ConsoleClient";
 import { ReceiverWithContext } from "../../messaging";
 import type { Schema } from "../../messaging/schema/background";
 import type { RequestContext } from "./types";
@@ -28,7 +28,7 @@ export class BackgroundMessageListener {
     consoleController: ConsoleController,
     @inject(FindController)
     findController: FindController,
-    @inject("ConsoleClient")
+    @inject(ConsoleClient)
     private readonly consoleClient: ConsoleClient,
   ) {
     this.receiver

--- a/src/background/operators/OperatorRegistry.ts
+++ b/src/background/operators/OperatorRegistry.ts
@@ -1,10 +1,12 @@
 import type { Operator } from "./types";
 
-export interface OperatorRegistory {
+export interface OperatorRegistry {
   register(op: Operator): void;
 
   getOperator(name: string): Operator | undefined;
 }
+
+export const OperatorRegistry = Symbol("OperatorRegistry");
 
 export class OperatorRegistryImpl {
   private readonly operatorNames: Map<string, Operator> = new Map();

--- a/src/background/operators/impls/CancelOperator.ts
+++ b/src/background/operators/impls/CancelOperator.ts
@@ -1,11 +1,11 @@
 import { inject, injectable } from "inversify";
 import type { Operator, OperatorContext } from "../types";
-import type { ConsoleClient } from "../../clients/ConsoleClient";
+import { ConsoleClient } from "../../clients/ConsoleClient";
 
 @injectable()
 export class CancelOperator implements Operator {
   constructor(
-    @inject("ConsoleClient")
+    @inject(ConsoleClient)
     private readonly consoleClient: ConsoleClient,
   ) {}
 

--- a/src/background/operators/impls/FocusOperator.ts
+++ b/src/background/operators/impls/FocusOperator.ts
@@ -1,11 +1,11 @@
 import { inject, injectable } from "inversify";
 import type { Operator, OperatorContext } from "../types";
-import type { ContentMessageClient } from "../../clients/ContentMessageClient";
+import { ContentMessageClient } from "../../clients/ContentMessageClient";
 
 @injectable()
 export class FocusOperator implements Operator {
   constructor(
-    @inject("ContentMessageClient")
+    @inject(ContentMessageClient)
     private readonly contentMessageClient: ContentMessageClient,
   ) {}
 

--- a/src/background/operators/impls/HorizontalScrollOperator.ts
+++ b/src/background/operators/impls/HorizontalScrollOperator.ts
@@ -1,15 +1,15 @@
 import { injectable, inject } from "inversify";
 import { z } from "zod";
 import type { Operator, OperatorContext } from "../types";
-import type { ContentMessageClient } from "../../clients/ContentMessageClient";
-import type { PropertySettings } from "../../settings/PropertySettings";
+import { ContentMessageClient } from "../../clients/ContentMessageClient";
+import { PropertySettings } from "../../settings/PropertySettings";
 
 @injectable()
 export class HorizontalScrollOperator implements Operator {
   constructor(
-    @inject("ContentMessageClient")
+    @inject(ContentMessageClient)
     private readonly contentMessageClient: ContentMessageClient,
-    @inject("PropertySettings")
+    @inject(PropertySettings)
     private readonly propertySettings: PropertySettings,
   ) {}
 

--- a/src/background/operators/impls/NavigateHistoryNextOperator.ts
+++ b/src/background/operators/impls/NavigateHistoryNextOperator.ts
@@ -1,11 +1,11 @@
 import { inject, injectable } from "inversify";
 import type { Operator, OperatorContext } from "../types";
-import type { NavigateClient } from "../../clients/NavigateClient";
+import { NavigateClient } from "../../clients/NavigateClient";
 
 @injectable()
 export class NavigateHistoryNextOperator implements Operator {
   constructor(
-    @inject("NavigateClient")
+    @inject(NavigateClient)
     private readonly navigateClient: NavigateClient,
   ) {}
 

--- a/src/background/operators/impls/NavigateHistoryPrevOperator.ts
+++ b/src/background/operators/impls/NavigateHistoryPrevOperator.ts
@@ -1,11 +1,11 @@
 import { inject, injectable } from "inversify";
 import type { Operator, OperatorContext } from "../types";
-import type { NavigateClient } from "../../clients/NavigateClient";
+import { NavigateClient } from "../../clients/NavigateClient";
 
 @injectable()
 export class NavigateHistoryPrevOperator implements Operator {
   constructor(
-    @inject("NavigateClient")
+    @inject(NavigateClient)
     private readonly navigateClient: NavigateClient,
   ) {}
 

--- a/src/background/operators/impls/NavigateLinkNextOperator.ts
+++ b/src/background/operators/impls/NavigateLinkNextOperator.ts
@@ -1,11 +1,11 @@
 import { inject, injectable } from "inversify";
 import type { Operator, OperatorContext } from "../types";
-import type { NavigateClient } from "../../clients/NavigateClient";
+import { NavigateClient } from "../../clients/NavigateClient";
 
 @injectable()
 export class NavigateLinkNextOperator implements Operator {
   constructor(
-    @inject("NavigateClient")
+    @inject(NavigateClient)
     private readonly navigateClient: NavigateClient,
   ) {}
 

--- a/src/background/operators/impls/NavigateLinkPrevOperator.ts
+++ b/src/background/operators/impls/NavigateLinkPrevOperator.ts
@@ -1,11 +1,11 @@
 import { inject, injectable } from "inversify";
 import type { Operator, OperatorContext } from "../types";
-import type { NavigateClient } from "../../clients/NavigateClient";
+import { NavigateClient } from "../../clients/NavigateClient";
 
 @injectable()
 export class NavigateLinkPrevOperator implements Operator {
   constructor(
-    @inject("NavigateClient")
+    @inject(NavigateClient)
     private readonly navigateClient: NavigateClient,
   ) {}
 

--- a/src/background/operators/impls/OpenHomeOperator.ts
+++ b/src/background/operators/impls/OpenHomeOperator.ts
@@ -1,12 +1,12 @@
 import { inject, injectable } from "inversify";
 import { z } from "zod";
 import type { Operator, OperatorContext } from "../types";
-import type { BrowserSettingRepository } from "../../repositories/BrowserSettingRepository";
+import { BrowserSettingRepository } from "../../repositories/BrowserSettingRepository";
 
 @injectable()
 export class OpenHomeOperator implements Operator {
   constructor(
-    @inject("BrowserSettingRepository")
+    @inject(BrowserSettingRepository)
     private readonly browserSettingRepository: BrowserSettingRepository,
   ) {}
 

--- a/src/background/operators/impls/PageScrollOperator.ts
+++ b/src/background/operators/impls/PageScrollOperator.ts
@@ -1,15 +1,15 @@
 import { injectable, inject } from "inversify";
 import { z } from "zod";
 import type { Operator, OperatorContext } from "../types";
-import type { ContentMessageClient } from "../../clients/ContentMessageClient";
-import type { PropertySettings } from "../../settings/PropertySettings";
+import { ContentMessageClient } from "../../clients/ContentMessageClient";
+import { PropertySettings } from "../../settings/PropertySettings";
 
 @injectable()
 export class PageScrollOperator implements Operator {
   constructor(
-    @inject("ContentMessageClient")
+    @inject(ContentMessageClient)
     private readonly contentMessageClient: ContentMessageClient,
-    @inject("PropertySettings")
+    @inject(PropertySettings)
     private readonly propertySettings: PropertySettings,
   ) {}
 

--- a/src/background/operators/impls/PasteOperator.ts
+++ b/src/background/operators/impls/PasteOperator.ts
@@ -1,16 +1,16 @@
 import { injectable, inject } from "inversify";
 import { z } from "zod";
 import type { Operator, OperatorContext } from "../types";
-import type { ClipboardRepository } from "../../repositories/ClipboardRepository";
-import type { SearchEngineSettings } from "../../settings/SearchEngineSettings";
+import { ClipboardRepository } from "../../repositories/ClipboardRepository";
+import { SearchEngineSettings } from "../../settings/SearchEngineSettings";
 import * as urls from "../../../shared/urls";
 
 @injectable()
 export class PasteOperator implements Operator {
   constructor(
-    @inject("ClipboardRepository")
+    @inject(ClipboardRepository)
     private readonly clipboard: ClipboardRepository,
-    @inject("SearchEngineSettings")
+    @inject(SearchEngineSettings)
     private readonly searchEngineSettings: SearchEngineSettings,
   ) {}
 

--- a/src/background/operators/impls/RepeatLastOperator.ts
+++ b/src/background/operators/impls/RepeatLastOperator.ts
@@ -1,14 +1,14 @@
 import { injectable, inject } from "inversify";
 import type { Operator, OperatorContext } from "../types";
-import type { RepeatRepository } from "../../repositories/RepeatRepository";
-import type { OperatorRegistory } from "../../operators/OperatorRegistory";
+import { RepeatRepository } from "../../repositories/RepeatRepository";
+import { OperatorRegistry } from "../../operators/OperatorRegistry";
 
 @injectable()
 export class RepeatLastOperator implements Operator {
   constructor(
-    @inject("OperatorRegistory")
-    private readonly operatorRegistory: OperatorRegistory,
-    @inject("RepeatRepository")
+    @inject(OperatorRegistry)
+    private readonly operatorRegistry: OperatorRegistry,
+    @inject(RepeatRepository)
     private readonly repeatRepository: RepeatRepository,
   ) {}
 
@@ -23,7 +23,7 @@ export class RepeatLastOperator implements Operator {
     if (lastOp === null) {
       return Promise.resolve();
     }
-    const op = this.operatorRegistory.getOperator(lastOp.type);
+    const op = this.operatorRegistry.getOperator(lastOp.type);
     if (typeof op === "undefined") {
       throw new Error("unknown operation: " + lastOp.type);
     }

--- a/src/background/operators/impls/ScrollToBottomOperator.ts
+++ b/src/background/operators/impls/ScrollToBottomOperator.ts
@@ -1,14 +1,14 @@
 import { injectable, inject } from "inversify";
 import type { Operator, OperatorContext } from "../types";
-import type { ContentMessageClient } from "../../clients/ContentMessageClient";
-import type { PropertySettings } from "../../settings/PropertySettings";
+import { ContentMessageClient } from "../../clients/ContentMessageClient";
+import { PropertySettings } from "../../settings/PropertySettings";
 
 @injectable()
 export class ScrollToBottomOperator implements Operator {
   constructor(
-    @inject("ContentMessageClient")
+    @inject(ContentMessageClient)
     private readonly contentMessageClient: ContentMessageClient,
-    @inject("PropertySettings")
+    @inject(PropertySettings)
     private readonly propertySettings: PropertySettings,
   ) {}
 

--- a/src/background/operators/impls/ScrollToEndOperator.ts
+++ b/src/background/operators/impls/ScrollToEndOperator.ts
@@ -1,14 +1,14 @@
 import { injectable, inject } from "inversify";
 import type { Operator, OperatorContext } from "../types";
-import type { ContentMessageClient } from "../../clients/ContentMessageClient";
-import type { PropertySettings } from "../../settings/PropertySettings";
+import { ContentMessageClient } from "../../clients/ContentMessageClient";
+import { PropertySettings } from "../../settings/PropertySettings";
 
 @injectable()
 export class ScrollToEndOperator implements Operator {
   constructor(
-    @inject("ContentMessageClient")
+    @inject(ContentMessageClient)
     private readonly contentMessageClient: ContentMessageClient,
-    @inject("PropertySettings")
+    @inject(PropertySettings)
     private readonly propertySettings: PropertySettings,
   ) {}
 

--- a/src/background/operators/impls/ScrollToHomeOperator.ts
+++ b/src/background/operators/impls/ScrollToHomeOperator.ts
@@ -1,14 +1,14 @@
 import { injectable, inject } from "inversify";
 import type { Operator, OperatorContext } from "../types";
-import type { ContentMessageClient } from "../../clients/ContentMessageClient";
-import type { PropertySettings } from "../../settings/PropertySettings";
+import { ContentMessageClient } from "../../clients/ContentMessageClient";
+import { PropertySettings } from "../../settings/PropertySettings";
 
 @injectable()
 export class ScrollToHomeOperator implements Operator {
   constructor(
-    @inject("ContentMessageClient")
+    @inject(ContentMessageClient)
     private readonly contentMessageClient: ContentMessageClient,
-    @inject("PropertySettings")
+    @inject(PropertySettings)
     private readonly propertySettings: PropertySettings,
   ) {}
 

--- a/src/background/operators/impls/ScrollToTopOperator.ts
+++ b/src/background/operators/impls/ScrollToTopOperator.ts
@@ -1,14 +1,14 @@
 import { injectable, inject } from "inversify";
 import type { Operator, OperatorContext } from "../types";
-import type { ContentMessageClient } from "../../clients/ContentMessageClient";
-import type { PropertySettings } from "../../settings/PropertySettings";
+import { ContentMessageClient } from "../../clients/ContentMessageClient";
+import { PropertySettings } from "../../settings/PropertySettings";
 
 @injectable()
 export class ScrollToTopOperator implements Operator {
   constructor(
-    @inject("ContentMessageClient")
+    @inject(ContentMessageClient)
     private readonly contentMessageClient: ContentMessageClient,
-    @inject("PropertySettings")
+    @inject(PropertySettings)
     private readonly propertySettings: PropertySettings,
   ) {}
 

--- a/src/background/operators/impls/SelectPreviousSelectedTabOperator.ts
+++ b/src/background/operators/impls/SelectPreviousSelectedTabOperator.ts
@@ -1,11 +1,11 @@
 import { inject, injectable } from "inversify";
 import type { Operator } from "../types";
-import type { LastSelectedTabRepository } from "../../repositories/LastSelectedTabRepository";
+import { LastSelectedTabRepository } from "../../repositories/LastSelectedTabRepository";
 
 @injectable()
 export class SelectPreviousSelectedTabOperator implements Operator {
   constructor(
-    @inject("LastSelectedTabRepository")
+    @inject(LastSelectedTabRepository)
     private readonly lastSelectedTabRepository: LastSelectedTabRepository,
   ) {}
 

--- a/src/background/operators/impls/ShowAddBookmarkOperator.ts
+++ b/src/background/operators/impls/ShowAddBookmarkOperator.ts
@@ -1,12 +1,12 @@
 import { inject, injectable } from "inversify";
 import { z } from "zod";
 import type { Operator, OperatorContext } from "../types";
-import type { ConsoleClient } from "../../clients/ConsoleClient";
+import { ConsoleClient } from "../../clients/ConsoleClient";
 
 @injectable()
 export class ShowAddBookmarkOperator implements Operator {
   constructor(
-    @inject("ConsoleClient")
+    @inject(ConsoleClient)
     private readonly consoleClient: ConsoleClient,
   ) {}
 

--- a/src/background/operators/impls/ShowBufferCommandOperator.ts
+++ b/src/background/operators/impls/ShowBufferCommandOperator.ts
@@ -1,11 +1,11 @@
 import { inject, injectable } from "inversify";
 import type { Operator, OperatorContext } from "../types";
-import type { ConsoleClient } from "../../clients/ConsoleClient";
+import { ConsoleClient } from "../../clients/ConsoleClient";
 
 @injectable()
 export class ShowBufferCommandOperator implements Operator {
   constructor(
-    @inject("ConsoleClient")
+    @inject(ConsoleClient)
     private readonly consoleClient: ConsoleClient,
   ) {}
 

--- a/src/background/operators/impls/ShowCommandOperator.ts
+++ b/src/background/operators/impls/ShowCommandOperator.ts
@@ -1,11 +1,11 @@
 import { inject, injectable } from "inversify";
 import type { Operator, OperatorContext } from "../types";
-import type { ConsoleClient } from "../../clients/ConsoleClient";
+import { ConsoleClient } from "../../clients/ConsoleClient";
 
 @injectable()
 export class ShowCommandOperator implements Operator {
   constructor(
-    @inject("ConsoleClient")
+    @inject(ConsoleClient)
     private readonly consoleClient: ConsoleClient,
   ) {}
 

--- a/src/background/operators/impls/ShowOpenCommandOperator.ts
+++ b/src/background/operators/impls/ShowOpenCommandOperator.ts
@@ -1,12 +1,12 @@
 import { inject, injectable } from "inversify";
 import { z } from "zod";
 import type { Operator, OperatorContext } from "../types";
-import type { ConsoleClient } from "../../clients/ConsoleClient";
+import { ConsoleClient } from "../../clients/ConsoleClient";
 
 @injectable()
 export class ShowOpenCommandOperator implements Operator {
   constructor(
-    @inject("ConsoleClient")
+    @inject(ConsoleClient)
     private readonly consoleClient: ConsoleClient,
   ) {}
 

--- a/src/background/operators/impls/ShowTabOpenCommandOperator.ts
+++ b/src/background/operators/impls/ShowTabOpenCommandOperator.ts
@@ -1,12 +1,12 @@
 import { inject, injectable } from "inversify";
 import { z } from "zod";
 import type { Operator, OperatorContext } from "../types";
-import type { ConsoleClient } from "../../clients/ConsoleClient";
+import { ConsoleClient } from "../../clients/ConsoleClient";
 
 @injectable()
 export class ShowTabOpenCommandOperator implements Operator {
   constructor(
-    @inject("ConsoleClient")
+    @inject(ConsoleClient)
     private readonly consoleClient: ConsoleClient,
   ) {}
 

--- a/src/background/operators/impls/ShowWinOpenCommandOperator.ts
+++ b/src/background/operators/impls/ShowWinOpenCommandOperator.ts
@@ -1,12 +1,12 @@
 import { inject, injectable } from "inversify";
 import { z } from "zod";
 import type { Operator, OperatorContext } from "../types";
-import type { ConsoleClient } from "../../clients/ConsoleClient";
+import { ConsoleClient } from "../../clients/ConsoleClient";
 
 @injectable()
 export class ShowWinOpenCommandOperator implements Operator {
   constructor(
-    @inject("ConsoleClient")
+    @inject(ConsoleClient)
     private readonly consoleClient: ConsoleClient,
   ) {}
 

--- a/src/background/operators/impls/StartFindOperator.ts
+++ b/src/background/operators/impls/StartFindOperator.ts
@@ -1,11 +1,11 @@
 import { inject, injectable } from "inversify";
 import type { Operator, OperatorContext } from "../types";
-import type { ConsoleClient } from "../../clients/ConsoleClient";
+import { ConsoleClient } from "../../clients/ConsoleClient";
 
 @injectable()
 export class StartFindOperator implements Operator {
   constructor(
-    @inject("ConsoleClient")
+    @inject(ConsoleClient)
     private readonly consoleClient: ConsoleClient,
   ) {}
 

--- a/src/background/operators/impls/VerticalScrollOperator.ts
+++ b/src/background/operators/impls/VerticalScrollOperator.ts
@@ -1,15 +1,15 @@
 import { inject, injectable } from "inversify";
 import { z } from "zod";
 import type { Operator, OperatorContext } from "../types";
-import type { ContentMessageClient } from "../../clients/ContentMessageClient";
-import type { PropertySettings } from "../../settings/PropertySettings";
+import { ContentMessageClient } from "../../clients/ContentMessageClient";
+import { PropertySettings } from "../../settings/PropertySettings";
 
 @injectable()
 export class VerticalScrollOperator implements Operator {
   constructor(
-    @inject("ContentMessageClient")
+    @inject(ContentMessageClient)
     private readonly contentMessageClient: ContentMessageClient,
-    @inject("PropertySettings")
+    @inject(PropertySettings)
     private readonly propertySettings: PropertySettings,
   ) {}
 

--- a/src/background/operators/impls/YankOperator.ts
+++ b/src/background/operators/impls/YankOperator.ts
@@ -1,14 +1,14 @@
 import { injectable, inject } from "inversify";
 import type { Operator, OperatorContext } from "../types";
-import type { ClipboardRepository } from "../../repositories/ClipboardRepository";
-import type { ConsoleClient } from "../../clients/ConsoleClient";
+import { ClipboardRepository } from "../../repositories/ClipboardRepository";
+import { ConsoleClient } from "../../clients/ConsoleClient";
 
 @injectable()
 export class YankOperator implements Operator {
   constructor(
-    @inject("ClipboardRepository")
+    @inject(ClipboardRepository)
     private readonly clipboard: ClipboardRepository,
-    @inject("ConsoleClient")
+    @inject(ConsoleClient)
     private readonly consoleClient: ConsoleClient,
   ) {}
 

--- a/src/background/operators/index.ts
+++ b/src/background/operators/index.ts
@@ -1,5 +1,4 @@
 import { inject, injectable } from "inversify";
-import type { OperatorRegistory } from "./OperatorRegistory";
 import { EnableAddonOperator } from "./impls/EnableAddonOperator";
 import { DisableAddonOperator } from "./impls/DisableAddonOperator";
 import { ToggleAddonOperator } from "./impls/ToggleAddonOperator";
@@ -63,11 +62,14 @@ import { OpenCommandHintOperator } from "./impls/OpenCommandHintOperator";
 import { TabopenCommandHintOperator } from "./impls/TabopenCommandHintOperator";
 import { WinopenCommandHintOperator } from "./impls/WinopenCommandHintOperator";
 import { OpenSourceHintOperator } from "./impls/OpenSourceHintOperator";
-import type { RepeatRepository } from "../repositories/RepeatRepository";
-import { OperatorRegistryImpl } from "./OperatorRegistory";
+import { RepeatRepository } from "../repositories/RepeatRepository";
+import {
+  type OperatorRegistry,
+  OperatorRegistryImpl,
+} from "./OperatorRegistry";
 
 @injectable()
-export class OperatorRegistoryFactory {
+export class OperatorRegistryFactory {
   constructor(
     @inject(EnableAddonOperator)
     private readonly enableAddonOperator: EnableAddonOperator,
@@ -193,11 +195,11 @@ export class OperatorRegistoryFactory {
     private readonly winopenCommandHintOperator: WinopenCommandHintOperator,
     @inject(OpenSourceHintOperator)
     private readonly openSourceHintOperator: OpenSourceHintOperator,
-    @inject("RepeatRepository")
+    @inject(RepeatRepository)
     private readonly repeatRepository: RepeatRepository,
   ) {}
 
-  create(): OperatorRegistory {
+  create(): OperatorRegistry {
     const r = new OperatorRegistryImpl();
     r.register(this.enableAddonOperator);
     r.register(this.disableAddonOperator);

--- a/src/background/presenters/Notifier.ts
+++ b/src/background/presenters/Notifier.ts
@@ -6,6 +6,8 @@ export interface Notifier {
   notifyUpdated(version: string, onclick: () => void): Promise<void>;
 }
 
+export const Notifier = Symbol("Notifier");
+
 @injectable()
 export class NotifierImpl implements NotifierImpl {
   async notifyUpdated(version: string, onclick: () => void): Promise<void> {

--- a/src/background/presenters/Notifier.ts
+++ b/src/background/presenters/Notifier.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 
 const NOTIFICATION_ID_UPDATE = "vimmatic-update";
 
@@ -8,7 +8,7 @@ export interface Notifier {
 
 export const Notifier = Symbol("Notifier");
 
-@injectable()
+@provide(Notifier)
 export class NotifierImpl implements NotifierImpl {
   async notifyUpdated(version: string, onclick: () => void): Promise<void> {
     const title = `Vimmatic ${version} has been installed`;

--- a/src/background/presenters/TabPresenter.ts
+++ b/src/background/presenters/TabPresenter.ts
@@ -12,6 +12,8 @@ export interface TabPresenter {
   getTab(tabId: number): Promise<Tab>;
 }
 
+export const TabPresenter = Symbol("TabPresenter");
+
 @injectable()
 export class TabPresenterImpl implements TabPresenter {
   async openToTab(url: string, tabId: number): Promise<void> {

--- a/src/background/presenters/TabPresenter.ts
+++ b/src/background/presenters/TabPresenter.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 
 export type Tab = chrome.tabs.Tab;
 
@@ -14,7 +14,7 @@ export interface TabPresenter {
 
 export const TabPresenter = Symbol("TabPresenter");
 
-@injectable()
+@provide(TabPresenter)
 export class TabPresenterImpl implements TabPresenter {
   async openToTab(url: string, tabId: number): Promise<void> {
     await chrome.tabs.update(tabId, { url });

--- a/src/background/presenters/ToolbarPresenter.ts
+++ b/src/background/presenters/ToolbarPresenter.ts
@@ -6,6 +6,8 @@ export interface ToolbarPresenter {
   onClick(listener: (arg: chrome.tabs.Tab) => void): void;
 }
 
+export const ToolbarPresenter = Symbol("ToolbarPresenter");
+
 @injectable()
 export class ToolbarPresenterImpl {
   async setEnabled(enabled: boolean): Promise<void> {

--- a/src/background/presenters/ToolbarPresenter.ts
+++ b/src/background/presenters/ToolbarPresenter.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 
 export interface ToolbarPresenter {
   setEnabled(enabled: boolean): Promise<void>;
@@ -8,7 +8,7 @@ export interface ToolbarPresenter {
 
 export const ToolbarPresenter = Symbol("ToolbarPresenter");
 
-@injectable()
+@provide(ToolbarPresenter)
 export class ToolbarPresenterImpl {
   async setEnabled(enabled: boolean): Promise<void> {
     const path = enabled

--- a/src/background/property/PropertyRegistry.ts
+++ b/src/background/property/PropertyRegistry.ts
@@ -8,6 +8,8 @@ export interface PropertyRegistry {
   getProperties(): Property[];
 }
 
+export const PropertyRegistry = Symbol("PropertyRegistry");
+
 export class PropertyRegistryImpl {
   private readonly properties: Property[] = [];
 

--- a/src/background/repositories/AddonEnabledRepository.ts
+++ b/src/background/repositories/AddonEnabledRepository.ts
@@ -19,6 +19,8 @@ type OnChangeListener = (values: {
 }) => void;
 const listeners: OnChangeListener[] = [];
 
+export const AddonEnabledRepository = Symbol("AddonEnabledRepository");
+
 @injectable()
 export class AddonEnabledRepositoryImpl implements AddonEnabledRepository {
   constructor(

--- a/src/background/repositories/AddonEnabledRepository.ts
+++ b/src/background/repositories/AddonEnabledRepository.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { type LocalCache, LocalCacheImpl } from "../db/LocalStorage";
 
 export interface AddonEnabledRepository {
@@ -21,7 +21,7 @@ const listeners: OnChangeListener[] = [];
 
 export const AddonEnabledRepository = Symbol("AddonEnabledRepository");
 
-@injectable()
+@provide(AddonEnabledRepository)
 export class AddonEnabledRepositoryImpl implements AddonEnabledRepository {
   constructor(
     private readonly cache: LocalCache<boolean> = new LocalCacheImpl<boolean>(

--- a/src/background/repositories/BrowserSettingRepository.ts
+++ b/src/background/repositories/BrowserSettingRepository.ts
@@ -5,6 +5,8 @@ export interface BrowserSettingRepository {
   getHomepageUrls(): Promise<string[]>;
 }
 
+export const BrowserSettingRepository = Symbol("BrowserSettingRepository");
+
 @injectable()
 export class FirefoxBrowserSettingRepositoryImpl
   implements BrowserSettingRepository

--- a/src/background/repositories/ClipboardRepository.ts
+++ b/src/background/repositories/ClipboardRepository.ts
@@ -6,6 +6,8 @@ export interface ClipboardRepository {
   write(value: string): Promise<void>;
 }
 
+export const ClipboardRepository = Symbol("ClipboardRepository");
+
 @injectable()
 export class FirefoxClipboardRepositoryImpl implements ClipboardRepository {
   async read(): Promise<string> {

--- a/src/background/repositories/FindHistoryRepository.ts
+++ b/src/background/repositories/FindHistoryRepository.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { type LocalCache, LocalCacheImpl } from "../db/LocalStorage";
 
 type State = string[];
@@ -11,7 +11,7 @@ export interface FindHistoryRepository {
 
 export const FindHistoryRepository = Symbol("FindHistoryRepository");
 
-@injectable()
+@provide(FindHistoryRepository)
 export class FindHistoryRepositoryImpl implements FindHistoryRepository {
   constructor(
     private readonly cache: LocalCache<State> = new LocalCacheImpl(

--- a/src/background/repositories/FindHistoryRepository.ts
+++ b/src/background/repositories/FindHistoryRepository.ts
@@ -9,6 +9,8 @@ export interface FindHistoryRepository {
   query(prefix: string): Promise<string[]>;
 }
 
+export const FindHistoryRepository = Symbol("FindHistoryRepository");
+
 @injectable()
 export class FindHistoryRepositoryImpl implements FindHistoryRepository {
   constructor(

--- a/src/background/repositories/FindRepository.ts
+++ b/src/background/repositories/FindRepository.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { type LocalCache, LocalCacheImpl } from "../db/LocalStorage";
 
 export type FindState = {
@@ -25,7 +25,7 @@ export interface FindRepository {
 
 export const FindRepository = Symbol("FindRepository");
 
-@injectable()
+@provide(FindRepository)
 export class FindRepositoryImpl implements FindRepository {
   constructor(
     private readonly cache: LocalCache<State> = new LocalCacheImpl(

--- a/src/background/repositories/FindRepository.ts
+++ b/src/background/repositories/FindRepository.ts
@@ -23,6 +23,8 @@ export interface FindRepository {
   deleteLocalState(tabId: number): Promise<void>;
 }
 
+export const FindRepository = Symbol("FindRepository");
+
 @injectable()
 export class FindRepositoryImpl implements FindRepository {
   constructor(

--- a/src/background/repositories/HintRepository.ts
+++ b/src/background/repositories/HintRepository.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { type LocalCache, LocalCacheImpl } from "../db/LocalStorage";
 import type { HintTarget } from "../hint/types";
 
@@ -39,7 +39,7 @@ type State = {
 
 export const HintRepository = Symbol("HintRepository");
 
-@injectable()
+@provide(HintRepository)
 export class HintRepositoryImpl implements HintRepository {
   constructor(
     private readonly cache: LocalCache<State> = new LocalCacheImpl(

--- a/src/background/repositories/HintRepository.ts
+++ b/src/background/repositories/HintRepository.ts
@@ -37,6 +37,8 @@ type State = {
   keys: string[];
 };
 
+export const HintRepository = Symbol("HintRepository");
+
 @injectable()
 export class HintRepositoryImpl implements HintRepository {
   constructor(

--- a/src/background/repositories/LastSelectedTabRepository.ts
+++ b/src/background/repositories/LastSelectedTabRepository.ts
@@ -12,6 +12,8 @@ type State = {
   currentSelected?: number;
 };
 
+export const LastSelectedTabRepository = Symbol("LastSelectedTabRepository");
+
 @injectable()
 export class LastSelectedTabRepositoryImpl
   implements LastSelectedTabRepository

--- a/src/background/repositories/LastSelectedTabRepository.ts
+++ b/src/background/repositories/LastSelectedTabRepository.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { type LocalCache, LocalCacheImpl } from "../db/LocalStorage";
 
 export interface LastSelectedTabRepository {
@@ -14,7 +14,7 @@ type State = {
 
 export const LastSelectedTabRepository = Symbol("LastSelectedTabRepository");
 
-@injectable()
+@provide(LastSelectedTabRepository)
 export class LastSelectedTabRepositoryImpl
   implements LastSelectedTabRepository
 {

--- a/src/background/repositories/MarkRepository.ts
+++ b/src/background/repositories/MarkRepository.ts
@@ -28,6 +28,8 @@ export interface MarkRepository {
   setLocalMark(tabId: number, key: string, mark: LocalMark): Promise<void>;
 }
 
+export const MarkRepository = Symbol("MarkRepository");
+
 @injectable()
 export class MarkRepositoryImpl implements MarkRepository {
   constructor(

--- a/src/background/repositories/MarkRepository.ts
+++ b/src/background/repositories/MarkRepository.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { type LocalCache, LocalCacheImpl } from "../db/LocalStorage";
 
 export type GlobalMark = {
@@ -30,7 +30,7 @@ export interface MarkRepository {
 
 export const MarkRepository = Symbol("MarkRepository");
 
-@injectable()
+@provide(MarkRepository)
 export class MarkRepositoryImpl implements MarkRepository {
   constructor(
     private readonly cache: LocalCache<MarkData> = new LocalCacheImpl(

--- a/src/background/repositories/ModeRepository.ts
+++ b/src/background/repositories/ModeRepository.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { type LocalCache, LocalCacheImpl } from "../db/LocalStorage";
 import { Mode } from "../../shared/mode";
 
@@ -11,7 +11,7 @@ type State = Mode;
 
 export const ModeRepository = Symbol("ModeRepository");
 
-@injectable()
+@provide(ModeRepository)
 export class ModeRepositoryImpl implements ModeRepository {
   constructor(
     private readonly localCache: LocalCache<State> = new LocalCacheImpl<State>(

--- a/src/background/repositories/ModeRepository.ts
+++ b/src/background/repositories/ModeRepository.ts
@@ -9,6 +9,8 @@ export interface ModeRepository {
 
 type State = Mode;
 
+export const ModeRepository = Symbol("ModeRepository");
+
 @injectable()
 export class ModeRepositoryImpl implements ModeRepository {
   constructor(

--- a/src/background/repositories/ReadyFrameRepository.ts
+++ b/src/background/repositories/ReadyFrameRepository.ts
@@ -11,6 +11,8 @@ export interface ReadyFrameRepository {
   getFrameIds(tabId: number): Promise<number[] | undefined>;
 }
 
+export const ReadyFrameRepository = Symbol("ReadyFrameRepository");
+
 @injectable()
 export class ReadyFrameRepositoryImpl implements ReadyFrameRepository {
   constructor(

--- a/src/background/repositories/ReadyFrameRepository.ts
+++ b/src/background/repositories/ReadyFrameRepository.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { type LocalCache, LocalCacheImpl } from "../db/LocalStorage";
 
 type State = { [tabId: number]: number[] };
@@ -13,7 +13,7 @@ export interface ReadyFrameRepository {
 
 export const ReadyFrameRepository = Symbol("ReadyFrameRepository");
 
-@injectable()
+@provide(ReadyFrameRepository)
 export class ReadyFrameRepositoryImpl implements ReadyFrameRepository {
   constructor(
     private readonly cache: LocalCache<State> = new LocalCacheImpl(

--- a/src/background/repositories/RepeatRepository.ts
+++ b/src/background/repositories/RepeatRepository.ts
@@ -8,6 +8,8 @@ export interface RepeatRepository {
   setLastOperation(op: Operation): Promise<void>;
 }
 
+export const RepeatRepository = Symbol("RepeatRepository");
+
 @injectable()
 export class RepeatRepositoryImpl implements RepeatRepository {
   constructor(

--- a/src/background/repositories/RepeatRepository.ts
+++ b/src/background/repositories/RepeatRepository.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { type LocalCache, LocalCacheImpl } from "../db/LocalStorage";
 import type { Operation } from "../../shared/operation";
 
@@ -10,7 +10,7 @@ export interface RepeatRepository {
 
 export const RepeatRepository = Symbol("RepeatRepository");
 
-@injectable()
+@provide(RepeatRepository)
 export class RepeatRepositoryImpl implements RepeatRepository {
   constructor(
     private readonly cache: LocalCache<Operation | null> = new LocalCacheImpl(

--- a/src/background/settings/PropertySettings.ts
+++ b/src/background/settings/PropertySettings.ts
@@ -1,6 +1,6 @@
 import { injectable, inject } from "inversify";
-import type { PropertyRegistry } from "../property/PropertyRegistry";
-import type { SettingsRepository } from "./SettingsRepository";
+import { PropertyRegistry } from "../property/PropertyRegistry";
+import { SettingsRepository } from "./SettingsRepository";
 
 export interface PropertySettings {
   setProperty(name: string, value: string | number | boolean): Promise<void>;
@@ -8,12 +8,14 @@ export interface PropertySettings {
   getProperty(name: string): Promise<string | number | boolean>;
 }
 
+export const PropertySettings = Symbol("PropertySettings");
+
 @injectable()
 export class PropertySettingsImpl {
   constructor(
-    @inject("SettingsRepository")
+    @inject(SettingsRepository)
     private readonly settingsRepository: SettingsRepository,
-    @inject("PropertyRegistry")
+    @inject(PropertyRegistry)
     private readonly propertyRegistry: PropertyRegistry,
   ) {}
 

--- a/src/background/settings/PropertySettings.ts
+++ b/src/background/settings/PropertySettings.ts
@@ -1,4 +1,5 @@
-import { injectable, inject } from "inversify";
+import { inject } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { PropertyRegistry } from "../property/PropertyRegistry";
 import { SettingsRepository } from "./SettingsRepository";
 
@@ -10,7 +11,7 @@ export interface PropertySettings {
 
 export const PropertySettings = Symbol("PropertySettings");
 
-@injectable()
+@provide(PropertySettings)
 export class PropertySettingsImpl {
   constructor(
     @inject(SettingsRepository)

--- a/src/background/settings/SearchEngineSettings.ts
+++ b/src/background/settings/SearchEngineSettings.ts
@@ -1,5 +1,5 @@
 import { injectable, inject } from "inversify";
-import type { SettingsRepository } from "./SettingsRepository";
+import { SettingsRepository } from "./SettingsRepository";
 import type { Search } from "../../shared/search";
 import { defaultSettings } from "../../settings";
 
@@ -7,10 +7,12 @@ export interface SearchEngineSettings {
   get(): Promise<Search>;
 }
 
+export const SearchEngineSettings = Symbol("SearchEngineSettings");
+
 @injectable()
 export class SearchEngineSettingsImpl {
   constructor(
-    @inject("SettingsRepository")
+    @inject(SettingsRepository)
     private readonly settingsRepository: SettingsRepository,
   ) {}
 

--- a/src/background/settings/SearchEngineSettings.ts
+++ b/src/background/settings/SearchEngineSettings.ts
@@ -1,4 +1,5 @@
-import { injectable, inject } from "inversify";
+import { inject } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { SettingsRepository } from "./SettingsRepository";
 import type { Search } from "../../shared/search";
 import { defaultSettings } from "../../settings";
@@ -9,7 +10,7 @@ export interface SearchEngineSettings {
 
 export const SearchEngineSettings = Symbol("SearchEngineSettings");
 
-@injectable()
+@provide(SearchEngineSettings)
 export class SearchEngineSettingsImpl {
   constructor(
     @inject(SettingsRepository)

--- a/src/background/settings/SettingsRepository.ts
+++ b/src/background/settings/SettingsRepository.ts
@@ -1,4 +1,5 @@
-import { injectable, inject } from "inversify";
+import { inject } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { type LocalCache, LocalCacheImpl } from "../db/LocalStorage";
 import type { Settings } from "../../shared/settings";
 import { defaultSettings, serialize, deserialize } from "../../settings";
@@ -19,7 +20,7 @@ export const PermanentSettingsRepository = Symbol(
   "PermanentSettingsRepository",
 );
 
-@injectable()
+@provide(PermanentSettingsRepository)
 export class PermanentSettingsRepositoryImpl implements SettingsRepository {
   async load(): Promise<Settings> {
     const { settings } = await chrome.storage.sync.get("settings");
@@ -66,7 +67,7 @@ export class PermanentSettingsRepositoryImpl implements SettingsRepository {
   }
 }
 
-@injectable()
+@provide(SettingsRepository)
 export class TransientSettingsRepositoryImpl implements SettingsRepository {
   constructor(
     @inject(PermanentSettingsRepository)

--- a/src/background/settings/SettingsRepository.ts
+++ b/src/background/settings/SettingsRepository.ts
@@ -14,8 +14,13 @@ export interface SettingsRepository {
   onChanged(f: OnChangeListener): void;
 }
 
+export const SettingsRepository = Symbol("SettingsRepository");
+export const PermanentSettingsRepository = Symbol(
+  "PermanentSettingsRepository",
+);
+
 @injectable()
-export class PermanentSettingsRepository implements SettingsRepository {
+export class PermanentSettingsRepositoryImpl implements SettingsRepository {
   async load(): Promise<Settings> {
     const { settings } = await chrome.storage.sync.get("settings");
     if (!settings) {
@@ -62,13 +67,13 @@ export class PermanentSettingsRepository implements SettingsRepository {
 }
 
 @injectable()
-export class TransientSettingsRepository implements SettingsRepository {
+export class TransientSettingsRepositoryImpl implements SettingsRepository {
   constructor(
-    @inject("PermanentSettingsRepository")
+    @inject(PermanentSettingsRepository)
     private readonly permanent: SettingsRepository,
     private readonly cache: LocalCache<
       SerializedSettings | undefined
-    > = new LocalCacheImpl(TransientSettingsRepository.name, undefined),
+    > = new LocalCacheImpl(TransientSettingsRepositoryImpl.name, undefined),
   ) {
     this.permanent.onChanged(this.sync.bind(this));
   }

--- a/src/background/settings/StyleSettings.ts
+++ b/src/background/settings/StyleSettings.ts
@@ -1,4 +1,5 @@
-import { injectable, inject } from "inversify";
+import { inject } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { SettingsRepository } from "./SettingsRepository";
 import type { ComponentName } from "../../shared/styles";
 import { defaultSettings } from "../../settings";
@@ -9,7 +10,7 @@ export interface StyleSettings {
 
 export const StyleSettings = Symbol("StyleSettings");
 
-@injectable()
+@provide(StyleSettings)
 export class StyleSettingsImpl {
   constructor(
     @inject(SettingsRepository)

--- a/src/background/settings/StyleSettings.ts
+++ b/src/background/settings/StyleSettings.ts
@@ -1,5 +1,5 @@
 import { injectable, inject } from "inversify";
-import type { SettingsRepository } from "./SettingsRepository";
+import { SettingsRepository } from "./SettingsRepository";
 import type { ComponentName } from "../../shared/styles";
 import { defaultSettings } from "../../settings";
 
@@ -7,10 +7,12 @@ export interface StyleSettings {
   getStyle(name: string): Promise<Record<string, string>>;
 }
 
+export const StyleSettings = Symbol("StyleSettings");
+
 @injectable()
 export class StyleSettingsImpl {
   constructor(
-    @inject("SettingsRepository")
+    @inject(SettingsRepository)
     private readonly settingsRepository: SettingsRepository,
   ) {}
 

--- a/src/background/settings/Validator.ts
+++ b/src/background/settings/Validator.ts
@@ -1,15 +1,15 @@
 import { injectable, inject } from "inversify";
 import type { Settings } from "../../shared/settings";
-import type { PropertyRegistry } from "../property/PropertyRegistry";
-import type { OperatorRegistory } from "../operators/OperatorRegistory";
+import { PropertyRegistry } from "../property/PropertyRegistry";
+import { OperatorRegistry } from "../operators/OperatorRegistry";
 
 @injectable()
 export class Validator {
   constructor(
-    @inject("PropertyRegistry")
+    @inject(PropertyRegistry)
     private readonly propertyRegistry: PropertyRegistry,
-    @inject("OperatorRegistory")
-    private readonly operatorRegistory: OperatorRegistory,
+    @inject(OperatorRegistry)
+    private readonly operatorRegistry: OperatorRegistry,
   ) {}
 
   validate(settings: Settings) {
@@ -28,7 +28,7 @@ export class Validator {
 
     const keymapEntries = settings.keymaps?.entries() || [];
     keymapEntries.forEach(([key, { type, props }]) => {
-      const op = this.operatorRegistory.getOperator(type);
+      const op = this.operatorRegistry.getOperator(type);
       if (typeof op === "undefined") {
         throw new Error("Unknown keymap: " + type);
       }

--- a/src/background/usecases/AddonEnabledEventUseCase.ts
+++ b/src/background/usecases/AddonEnabledEventUseCase.ts
@@ -1,20 +1,20 @@
 import { inject, injectable } from "inversify";
-import type { ToolbarPresenter } from "../presenters/ToolbarPresenter";
+import { ToolbarPresenter } from "../presenters/ToolbarPresenter";
 import { AddonEnabledUseCase } from "./AddonEnabledUseCase";
-import type { AddonEnabledRepository } from "../repositories/AddonEnabledRepository";
-import type { AddonEnabledClient } from "../clients/AddonEnabledClient";
+import { AddonEnabledRepository } from "../repositories/AddonEnabledRepository";
+import { AddonEnabledClient } from "../clients/AddonEnabledClient";
 import { EventUseCaseHelper } from "./EventUseCaseHelper";
 
 @injectable()
 export class AddonEnabledEventUseCase {
   constructor(
-    @inject("ToolbarPresenter")
+    @inject(ToolbarPresenter)
     private readonly toolbarPresenter: ToolbarPresenter,
     @inject(AddonEnabledUseCase)
     private readonly addonEnabledUseCase: AddonEnabledUseCase,
-    @inject("AddonEnabledRepository")
+    @inject(AddonEnabledRepository)
     private readonly addonEnabledRepository: AddonEnabledRepository,
-    @inject("AddonEnabledClient")
+    @inject(AddonEnabledClient)
     private readonly addonEnabledClient: AddonEnabledClient,
     @inject(EventUseCaseHelper)
     private readonly eventUseCaseHelper: EventUseCaseHelper,

--- a/src/background/usecases/AddonEnabledUseCase.ts
+++ b/src/background/usecases/AddonEnabledUseCase.ts
@@ -1,13 +1,13 @@
 import { inject, injectable } from "inversify";
-import type { ToolbarPresenter } from "../presenters/ToolbarPresenter";
-import type { AddonEnabledRepository } from "../repositories/AddonEnabledRepository";
+import { ToolbarPresenter } from "../presenters/ToolbarPresenter";
+import { AddonEnabledRepository } from "../repositories/AddonEnabledRepository";
 
 @injectable()
 export class AddonEnabledUseCase {
   constructor(
-    @inject("ToolbarPresenter")
+    @inject(ToolbarPresenter)
     private readonly toolbarPresenter: ToolbarPresenter,
-    @inject("AddonEnabledRepository")
+    @inject(AddonEnabledRepository)
     private readonly addonEnabledRepository: AddonEnabledRepository,
   ) {}
 

--- a/src/background/usecases/CommandUseCase.ts
+++ b/src/background/usecases/CommandUseCase.ts
@@ -1,6 +1,6 @@
 import { injectable, inject } from "inversify";
 import type { Completions } from "../../shared/completions";
-import type { CommandRegistry } from "../command/CommandRegistry";
+import { CommandRegistry } from "../command/CommandRegistry";
 import type { RequestContext } from "../messaging/types";
 import type { CommandContext } from "../command/types";
 import { parseCommand, onCommandInputting } from "./parser";
@@ -8,7 +8,7 @@ import { parseCommand, onCommandInputting } from "./parser";
 @injectable()
 export class CommandUseCase {
   constructor(
-    @inject("CommandRegistry")
+    @inject(CommandRegistry)
     private readonly commandRegistry: CommandRegistry,
   ) {}
 

--- a/src/background/usecases/ConsoleUseCase.ts
+++ b/src/background/usecases/ConsoleUseCase.ts
@@ -1,10 +1,10 @@
 import { inject, injectable } from "inversify";
-import type { ConsoleFrameClient } from "../clients/ConsoleFrameClient";
+import { ConsoleFrameClient } from "../clients/ConsoleFrameClient";
 
 @injectable()
 export class ConsoleUseCase {
   constructor(
-    @inject("ConsoleFrameClient")
+    @inject(ConsoleFrameClient)
     private readonly consoleFrameClient: ConsoleFrameClient,
   ) {}
 

--- a/src/background/usecases/FindUseCase.ts
+++ b/src/background/usecases/FindUseCase.ts
@@ -1,25 +1,25 @@
 import { inject, injectable } from "inversify";
-import type { ConsoleClient } from "../clients/ConsoleClient";
-import type { FindRepository } from "../repositories/FindRepository";
-import type { FindHistoryRepository } from "../repositories/FindHistoryRepository";
-import type { PropertySettings } from "../settings/PropertySettings";
-import type { FindClient } from "../clients/FindClient";
-import type { ReadyFrameRepository } from "../repositories/ReadyFrameRepository";
+import { ConsoleClient } from "../clients/ConsoleClient";
+import { FindRepository } from "../repositories/FindRepository";
+import { FindHistoryRepository } from "../repositories/FindHistoryRepository";
+import { PropertySettings } from "../settings/PropertySettings";
+import { FindClient } from "../clients/FindClient";
+import { ReadyFrameRepository } from "../repositories/ReadyFrameRepository";
 
 @injectable()
 export class FindUseCase {
   constructor(
-    @inject("FindClient")
+    @inject(FindClient)
     private readonly findClient: FindClient,
-    @inject("FindRepository")
+    @inject(FindRepository)
     private readonly findRepository: FindRepository,
-    @inject("FindHistoryRepository")
+    @inject(FindHistoryRepository)
     private readonly findHistoryRepository: FindHistoryRepository,
-    @inject("ConsoleClient")
+    @inject(ConsoleClient)
     private readonly consoleClient: ConsoleClient,
-    @inject("ReadyFrameRepository")
+    @inject(ReadyFrameRepository)
     private readonly frameRepository: ReadyFrameRepository,
-    @inject("PropertySettings")
+    @inject(PropertySettings)
     private readonly propertySettings: PropertySettings,
   ) {}
 

--- a/src/background/usecases/HintKeyUseCase.ts
+++ b/src/background/usecases/HintKeyUseCase.ts
@@ -1,17 +1,17 @@
 import { injectable, inject } from "inversify";
-import type { HintClient } from "../clients/HintClient";
+import { HintClient } from "../clients/HintClient";
 import type { HintTarget } from "../hint/types";
-import type { HintRepository } from "../repositories/HintRepository";
-import type { HintActionFactory } from "../hint/HintActionFactory";
+import { HintRepository } from "../repositories/HintRepository";
+import { HintActionFactory } from "../hint/HintActionFactory";
 
 @injectable()
 export class HintKeyUseCase {
   constructor(
-    @inject("HintClient")
+    @inject(HintClient)
     private readonly hintClient: HintClient,
-    @inject("HintRepository")
+    @inject(HintRepository)
     private readonly hintRepository: HintRepository,
-    @inject("HintActionFactory")
+    @inject(HintActionFactory)
     private readonly hintActionFactory: HintActionFactory,
   ) {}
 

--- a/src/background/usecases/HintModeUseCase.ts
+++ b/src/background/usecases/HintModeUseCase.ts
@@ -1,27 +1,27 @@
 import { injectable, inject } from "inversify";
-import type { ReadyFrameRepository } from "../repositories/ReadyFrameRepository";
-import type { PropertySettings } from "../settings/PropertySettings";
-import type { TopFrameClient } from "../clients/TopFrameClient";
+import { ReadyFrameRepository } from "../repositories/ReadyFrameRepository";
+import { PropertySettings } from "../settings/PropertySettings";
+import { TopFrameClient } from "../clients/TopFrameClient";
 import type { HintTarget } from "../hint/types";
-import type { HintClient } from "../clients/HintClient";
-import type { HintRepository } from "../repositories/HintRepository";
-import type { HintActionFactory } from "../hint/HintActionFactory";
+import { HintClient } from "../clients/HintClient";
+import { HintRepository } from "../repositories/HintRepository";
+import { HintActionFactory } from "../hint/HintActionFactory";
 import { HintTagProducer } from "./HintTagProducer";
 
 @injectable()
 export class HintModeUseCase {
   constructor(
-    @inject("TopFrameClient")
+    @inject(TopFrameClient)
     private readonly topFrameClient: TopFrameClient,
-    @inject("HintClient")
+    @inject(HintClient)
     private readonly hintClient: HintClient,
-    @inject("ReadyFrameRepository")
+    @inject(ReadyFrameRepository)
     private readonly frameRepository: ReadyFrameRepository,
-    @inject("PropertySettings")
+    @inject(PropertySettings)
     private readonly propertySettings: PropertySettings,
-    @inject("HintRepository")
+    @inject(HintRepository)
     private readonly hintRepository: HintRepository,
-    @inject("HintActionFactory")
+    @inject(HintActionFactory)
     private readonly hintActionFactory: HintActionFactory,
   ) {}
 

--- a/src/background/usecases/MarkJumpUseCase.ts
+++ b/src/background/usecases/MarkJumpUseCase.ts
@@ -1,20 +1,20 @@
 import { inject, injectable } from "inversify";
-import type { MarkRepository } from "../repositories/MarkRepository";
-import type { ContentMessageClient } from "../clients/ContentMessageClient";
-import type { ConsoleClient } from "../clients/ConsoleClient";
-import type { PropertySettings } from "../settings/PropertySettings";
+import { MarkRepository } from "../repositories/MarkRepository";
+import { ContentMessageClient } from "../clients/ContentMessageClient";
+import { ConsoleClient } from "../clients/ConsoleClient";
+import { PropertySettings } from "../settings/PropertySettings";
 import { MarkHelper } from "./MarkHelper";
 
 @injectable()
 export class MarkJumpUseCase {
   constructor(
-    @inject("MarkRepository")
+    @inject(MarkRepository)
     private readonly markRepository: MarkRepository,
-    @inject("ConsoleClient")
+    @inject(ConsoleClient)
     private readonly consoleClient: ConsoleClient,
-    @inject("ContentMessageClient")
+    @inject(ContentMessageClient)
     private readonly contentMessageClient: ContentMessageClient,
-    @inject("PropertySettings")
+    @inject(PropertySettings)
     private readonly propertySettings: PropertySettings,
     @inject(MarkHelper)
     private readonly markHelper: MarkHelper,

--- a/src/background/usecases/MarkSetUseCase.ts
+++ b/src/background/usecases/MarkSetUseCase.ts
@@ -1,21 +1,21 @@
 import { inject, injectable } from "inversify";
-import type {
+import {
   MarkRepository,
-  GlobalMark,
-  LocalMark,
+  type GlobalMark,
+  type LocalMark,
 } from "../repositories/MarkRepository";
-import type { ContentMessageClient } from "../clients/ContentMessageClient";
-import type { ConsoleClient } from "../clients/ConsoleClient";
+import { ContentMessageClient } from "../clients/ContentMessageClient";
+import { ConsoleClient } from "../clients/ConsoleClient";
 import { MarkHelper } from "./MarkHelper";
 
 @injectable()
 export class MarkSetUseCase {
   constructor(
-    @inject("MarkRepository")
+    @inject(MarkRepository)
     private readonly markRepository: MarkRepository,
-    @inject("ConsoleClient")
+    @inject(ConsoleClient)
     private readonly consoleClient: ConsoleClient,
-    @inject("ContentMessageClient")
+    @inject(ContentMessageClient)
     private readonly contentMessageClient: ContentMessageClient,
     @inject(MarkHelper)
     private readonly markHelper: MarkHelper,

--- a/src/background/usecases/ModeUseCase.ts
+++ b/src/background/usecases/ModeUseCase.ts
@@ -1,14 +1,14 @@
 import { inject, injectable } from "inversify";
 import { Mode } from "../../shared/mode";
-import type { ModeClient } from "../clients/ModeClient";
-import type { ModeRepository } from "../repositories/ModeRepository";
+import { ModeClient } from "../clients/ModeClient";
+import { ModeRepository } from "../repositories/ModeRepository";
 
 @injectable()
 export class ModeUseCase {
   constructor(
-    @inject("ModeRepository")
+    @inject(ModeRepository)
     private readonly modeRepository: ModeRepository,
-    @inject("ModeClient")
+    @inject(ModeClient)
     private readonly modeClient: ModeClient,
   ) {}
 

--- a/src/background/usecases/OperationUseCase.ts
+++ b/src/background/usecases/OperationUseCase.ts
@@ -1,16 +1,16 @@
 import { inject, injectable } from "inversify";
 import type { OperatorContext } from "../operators/types";
 import type { Operation } from "../../shared/operation";
-import type { OperatorRegistory } from "../operators/OperatorRegistory";
-import type { RepeatRepository } from "../repositories/RepeatRepository";
+import { OperatorRegistry } from "../operators/OperatorRegistry";
+import { RepeatRepository } from "../repositories/RepeatRepository";
 import type { RequestContext } from "../messaging/types";
 
 @injectable()
 export class OperationUseCase {
   constructor(
-    @inject("OperatorRegistory")
-    private readonly operatorRegistory: OperatorRegistory,
-    @inject("RepeatRepository")
+    @inject(OperatorRegistry)
+    private readonly operatorRegistry: OperatorRegistry,
+    @inject(RepeatRepository)
     private readonly repeatRepository: RepeatRepository,
   ) {}
 
@@ -32,7 +32,7 @@ export class OperationUseCase {
     if (this.isRepeatable(op.type)) {
       await this.repeatRepository.setLastOperation(op);
     }
-    const got = this.operatorRegistory.getOperator(op.type);
+    const got = this.operatorRegistry.getOperator(op.type);
     if (typeof got === "undefined") {
       throw new Error("unknown operation: " + op.type);
     }

--- a/src/background/usecases/SettingsEventUseCase.ts
+++ b/src/background/usecases/SettingsEventUseCase.ts
@@ -1,14 +1,17 @@
 import { injectable, inject } from "inversify";
-import type { ContentMessageClient } from "../clients/ContentMessageClient";
-import type { SettingsRepository } from "../settings/SettingsRepository";
+import { ContentMessageClient } from "../clients/ContentMessageClient";
+import {
+  PermanentSettingsRepository,
+  type SettingsRepository,
+} from "../settings/SettingsRepository";
 import { EventUseCaseHelper } from "./EventUseCaseHelper";
 
 @injectable()
 export class SettingsEventUseCase {
   constructor(
-    @inject("PermanentSettingsRepository")
+    @inject(PermanentSettingsRepository)
     private readonly settingsRepository: SettingsRepository,
-    @inject("ContentMessageClient")
+    @inject(ContentMessageClient)
     private readonly contentMessageClient: ContentMessageClient,
     @inject(EventUseCaseHelper)
     private readonly eventUseCaseHelper: EventUseCaseHelper,

--- a/src/background/usecases/SettingsUseCase.ts
+++ b/src/background/usecases/SettingsUseCase.ts
@@ -1,18 +1,18 @@
 import { injectable, inject } from "inversify";
 import { serialize, deserialize } from "../../settings";
-import type { SettingsRepository } from "../settings/SettingsRepository";
-import type { PropertySettings } from "../settings/PropertySettings";
-import type { StyleSettings } from "../settings/StyleSettings";
+import { SettingsRepository } from "../settings/SettingsRepository";
+import { PropertySettings } from "../settings/PropertySettings";
+import { StyleSettings } from "../settings/StyleSettings";
 import { Validator } from "../settings/Validator";
 
 @injectable()
 export class SettingsUseCase {
   constructor(
-    @inject("SettingsRepository")
+    @inject(SettingsRepository)
     private readonly settingsRepository: SettingsRepository,
-    @inject("PropertySettings")
+    @inject(PropertySettings)
     private readonly propertySettings: PropertySettings,
-    @inject("StyleSettings")
+    @inject(StyleSettings)
     private readonly styleSettings: StyleSettings,
     @inject(Validator)
     private readonly validator: Validator,

--- a/src/background/usecases/VersionUseCase.ts
+++ b/src/background/usecases/VersionUseCase.ts
@@ -1,9 +1,12 @@
 import { injectable, inject } from "inversify";
-import type { Notifier } from "../presenters/Notifier";
+import { Notifier } from "../presenters/Notifier";
 
 @injectable()
 export class VersionUseCase {
-  constructor(@inject("Notifier") private notifier: Notifier) {}
+  constructor(
+    @inject(Notifier)
+    private notifier: Notifier,
+  ) {}
 
   notify(): Promise<void> {
     const manifest = chrome.runtime.getManifest();

--- a/src/content/Application.ts
+++ b/src/content/Application.ts
@@ -4,7 +4,7 @@ import { ContentMessageListener } from "./messaging/ContentMessageListener";
 import { KeyController } from "./controllers/KeyController";
 import { SettingsController } from "./controllers/SettingsController";
 import { InputDriver } from "./InputDriver";
-import type { ReadyStatusPresenter } from "./presenters/ReadyStatusPresenter";
+import { ReadyStatusPresenter } from "./presenters/ReadyStatusPresenter";
 
 @injectable()
 export class Application {
@@ -18,7 +18,7 @@ export class Application {
     private readonly keyController: KeyController,
     @inject(SettingsController)
     private readonly settingsController: SettingsController,
-    @inject("ReadyStatusPresenter")
+    @inject(ReadyStatusPresenter)
     private readonly readyStatusPresenter: ReadyStatusPresenter,
   ) {}
 

--- a/src/content/client/BackgroundKeyClient.ts
+++ b/src/content/client/BackgroundKeyClient.ts
@@ -1,4 +1,5 @@
-import { injectable, inject } from "inversify";
+import { inject } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import type { Key } from "../../shared/key";
 import { BackgroundMessageSender } from "./BackgroundMessageSender";
 
@@ -8,7 +9,7 @@ export interface BackgroundKeyClient {
 
 export const BackgroundKeyClient = Symbol("BackgroundKeyClient");
 
-@injectable()
+@provide(BackgroundKeyClient)
 export class BackgroundKeyClientImpl implements BackgroundKeyClient {
   constructor(
     @inject(BackgroundMessageSender)

--- a/src/content/client/BackgroundKeyClient.ts
+++ b/src/content/client/BackgroundKeyClient.ts
@@ -1,15 +1,17 @@
 import { injectable, inject } from "inversify";
 import type { Key } from "../../shared/key";
-import type { BackgroundMessageSender } from "./BackgroundMessageSender";
+import { BackgroundMessageSender } from "./BackgroundMessageSender";
 
 export interface BackgroundKeyClient {
   sendKey(key: Key): Promise<void>;
 }
 
+export const BackgroundKeyClient = Symbol("BackgroundKeyClient");
+
 @injectable()
 export class BackgroundKeyClientImpl implements BackgroundKeyClient {
   constructor(
-    @inject("BackgroundMessageSender")
+    @inject(BackgroundMessageSender)
     private readonly sender: BackgroundMessageSender,
   ) {}
 

--- a/src/content/client/BackgroundMessageSender.ts
+++ b/src/content/client/BackgroundMessageSender.ts
@@ -1,6 +1,8 @@
 import { Sender } from "../../messaging";
 import type { Schema, Key, Request } from "../../messaging/schema/background";
 
+export const BackgroundMessageSender = Symbol("BackgroundMessageSender");
+
 export const newSender = () => {
   const sender = new Sender<Schema>((type: Key, args: Request) => {
     if (process.env.NODE_ENV === "development") {

--- a/src/content/client/OperationClient.ts
+++ b/src/content/client/OperationClient.ts
@@ -1,4 +1,5 @@
-import { injectable, inject } from "inversify";
+import { inject } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import type { Operation } from "../../shared/operation";
 import { BackgroundMessageSender } from "./BackgroundMessageSender";
 
@@ -8,7 +9,7 @@ export interface OperationClient {
 
 export const OperationClient = Symbol("OperationClient");
 
-@injectable()
+@provide(OperationClient)
 export class OperationClientImpl implements OperationClient {
   constructor(
     @inject(BackgroundMessageSender)

--- a/src/content/client/OperationClient.ts
+++ b/src/content/client/OperationClient.ts
@@ -1,15 +1,17 @@
 import { injectable, inject } from "inversify";
 import type { Operation } from "../../shared/operation";
-import type { BackgroundMessageSender } from "./BackgroundMessageSender";
+import { BackgroundMessageSender } from "./BackgroundMessageSender";
 
 export interface OperationClient {
   execBackgroundOp(op: Operation, repeat: number): Promise<void>;
 }
 
+export const OperationClient = Symbol("OperationClient");
+
 @injectable()
 export class OperationClientImpl implements OperationClient {
   constructor(
-    @inject("BackgroundMessageSender")
+    @inject(BackgroundMessageSender)
     private readonly sender: BackgroundMessageSender,
   ) {}
 

--- a/src/content/client/SettingClient.ts
+++ b/src/content/client/SettingClient.ts
@@ -1,4 +1,5 @@
-import { injectable, inject } from "inversify";
+import { inject } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { deserialize } from "../../settings";
 import type { Settings } from "../../shared/settings";
 import { BackgroundMessageSender } from "./BackgroundMessageSender";
@@ -9,7 +10,7 @@ export interface SettingClient {
 
 export const SettingClient = Symbol("SettingClient");
 
-@injectable()
+@provide(SettingClient)
 export class SettingClientImpl {
   constructor(
     @inject(BackgroundMessageSender)

--- a/src/content/client/SettingClient.ts
+++ b/src/content/client/SettingClient.ts
@@ -1,16 +1,18 @@
 import { injectable, inject } from "inversify";
 import { deserialize } from "../../settings";
 import type { Settings } from "../../shared/settings";
-import type { BackgroundMessageSender } from "./BackgroundMessageSender";
+import { BackgroundMessageSender } from "./BackgroundMessageSender";
 
 export interface SettingClient {
   load(): Promise<Settings>;
 }
 
+export const SettingClient = Symbol("SettingClient");
+
 @injectable()
 export class SettingClientImpl {
   constructor(
-    @inject("BackgroundMessageSender")
+    @inject(BackgroundMessageSender)
     private readonly sender: BackgroundMessageSender,
   ) {}
 

--- a/src/content/client/TopFrameClient.ts
+++ b/src/content/client/TopFrameClient.ts
@@ -1,4 +1,5 @@
-import { injectable, inject } from "inversify";
+import { inject } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { WindowMessageSender } from "./WindowMessageSender";
 
 export interface TopFrameClient {
@@ -7,7 +8,7 @@ export interface TopFrameClient {
 
 export const TopFrameClient = Symbol("TopFrameClient");
 
-@injectable()
+@provide(TopFrameClient)
 export class TopFrameClientImpl implements TopFrameClient {
   constructor(
     @inject(WindowMessageSender)

--- a/src/content/client/TopFrameClient.ts
+++ b/src/content/client/TopFrameClient.ts
@@ -1,14 +1,16 @@
 import { injectable, inject } from "inversify";
-import type { WindowMessageSender } from "./WindowMessageSender";
+import { WindowMessageSender } from "./WindowMessageSender";
 
 export interface TopFrameClient {
   notifyFrameId(frameId: number): Promise<void>;
 }
 
+export const TopFrameClient = Symbol("TopFrameClient");
+
 @injectable()
 export class TopFrameClientImpl implements TopFrameClient {
   constructor(
-    @inject("WindowMessageSender")
+    @inject(WindowMessageSender)
     private readonly sender: WindowMessageSender,
   ) {}
 

--- a/src/content/client/WindowMessageSender.ts
+++ b/src/content/client/WindowMessageSender.ts
@@ -1,6 +1,8 @@
 import { SimplexSender } from "../../messaging";
 import type { Key, Schema, Request } from "../../messaging/schema/window";
 
+export const WindowMessageSender = Symbol("WindowMessageSender");
+
 /**
  * The window.postMessage() is used to identify a frame id of the <iframe>
  * element through the background script.  Only Firefox supports to get the

--- a/src/content/controllers/FocusController.ts
+++ b/src/content/controllers/FocusController.ts
@@ -1,10 +1,10 @@
 import { injectable, inject } from "inversify";
-import type { FocusPresenter } from "../presenters/FocusPresenter";
+import { FocusPresenter } from "../presenters/FocusPresenter";
 
 @injectable()
 export class FocusController {
   constructor(
-    @inject("FocusPresenter")
+    @inject(FocusPresenter)
     private readonly focusPresenter: FocusPresenter,
   ) {}
 

--- a/src/content/controllers/KeyController.ts
+++ b/src/content/controllers/KeyController.ts
@@ -1,17 +1,17 @@
 import { injectable, inject } from "inversify";
 import type { Key } from "../../shared/key";
 import { Mode } from "../../shared/mode";
-import type { ModeRepository } from "../repositories/ModeRepository";
-import type { BackgroundKeyClient } from "../client/BackgroundKeyClient";
+import { ModeRepository } from "../repositories/ModeRepository";
+import { BackgroundKeyClient } from "../client/BackgroundKeyClient";
 import { KeymapUseCase } from "../usecases/KeymapUseCase";
 import { OperationUseCase } from "../usecases/OperationUseCase";
 
 @injectable()
 export class KeyController {
   constructor(
-    @inject("ModeRepository")
+    @inject(ModeRepository)
     private readonly modeRepository: ModeRepository,
-    @inject("BackgroundKeyClient")
+    @inject(BackgroundKeyClient)
     private readonly backgroundKeyClient: BackgroundKeyClient,
     @inject(KeymapUseCase)
     private readonly keymapUseCase: KeymapUseCase,

--- a/src/content/controllers/ModeController.ts
+++ b/src/content/controllers/ModeController.ts
@@ -1,11 +1,11 @@
 import { injectable, inject } from "inversify";
 import type { Mode } from "../../shared/mode";
-import type { ModeRepository } from "../repositories/ModeRepository";
+import { ModeRepository } from "../repositories/ModeRepository";
 
 @injectable()
 export class ModeController {
   constructor(
-    @inject("ModeRepository")
+    @inject(ModeRepository)
     private readonly modeRepository: ModeRepository,
   ) {}
 

--- a/src/content/controllers/ScrollController.ts
+++ b/src/content/controllers/ScrollController.ts
@@ -1,10 +1,10 @@
 import { injectable, inject } from "inversify";
-import type { ScrollPresenter } from "../presenters/ScrollPresenter";
+import { ScrollPresenter } from "../presenters/ScrollPresenter";
 
 @injectable()
 export class ScrollController {
   constructor(
-    @inject("ScrollPresenter")
+    @inject(ScrollPresenter)
     private readonly scrollPresenter: ScrollPresenter,
   ) {}
 

--- a/src/content/controllers/SettingsController.ts
+++ b/src/content/controllers/SettingsController.ts
@@ -1,13 +1,13 @@
 import { injectable, inject } from "inversify";
 import { AddonEnabledUseCase } from "../usecases/AddonEnabledUseCase";
-import type { SettingRepository } from "../repositories/SettingRepository";
+import { SettingRepository } from "../repositories/SettingRepository";
 
 @injectable()
 export class SettingsController {
   constructor(
     @inject(AddonEnabledUseCase)
     private readonly addonEnabledUseCase: AddonEnabledUseCase,
-    @inject("SettingRepository")
+    @inject(SettingRepository)
     private readonly settingRepostory: SettingRepository,
   ) {}
 

--- a/src/content/di.ts
+++ b/src/content/di.ts
@@ -1,59 +1,7 @@
 /* eslint-disable max-len */
 
-import {
-  AddonEnabledRepository,
-  AddonEnabledRepositoryImpl,
-} from "./repositories/AddonEnabledRepository";
-import {
-  AddressRepository,
-  AddressRepositoryImpl,
-} from "./repositories/AddressRepository";
-import {
-  ConsoleFramePresenter,
-  ConsoleFramePresenterImpl,
-} from "./presenters/ConsoleFramePresenter";
-import {
-  FocusPresenter,
-  FocusPresenterImpl,
-} from "./presenters/FocusPresenter";
-import { HintPresenter, HintPresenterImpl } from "./presenters/HintPresenter";
-import {
-  KeymapRepository,
-  KeymapRepositoryImpl,
-} from "./repositories/KeymapRepository";
-import {
-  NavigationPresenter,
-  NavigationPresenterImpl,
-} from "./presenters/NavigationPresenter";
-import { OperationClient, OperationClientImpl } from "./client/OperationClient";
-import {
-  ScrollPresenter,
-  ScrollPresenterImpl,
-} from "./presenters/ScrollPresenter";
-import { SettingClient, SettingClientImpl } from "./client/SettingClient";
-import {
-  SettingRepository,
-  SettingRepositoryImpl,
-} from "./repositories/SettingRepository";
-import { FindPresenter, FindPresenterImpl } from "./presenters/FindPresenter";
-import {
-  BackgroundKeyClient,
-  BackgroundKeyClientImpl,
-} from "./client/BackgroundKeyClient";
-import {
-  ModeRepository,
-  ModeRepositoryImpl,
-} from "./repositories/ModeRepository";
-import { TopFrameClient, TopFrameClientImpl } from "./client/TopFrameClient";
-import {
-  FrameIdRepository,
-  FrameIdRepositoryImpl,
-} from "./repositories/FrameIdRepository";
-import {
-  ReadyStatusPresenter,
-  ReadyStatusPresenterImpl,
-} from "./presenters/ReadyStatusPresenter";
 import { Container } from "inversify";
+import { buildProviderModule } from "inversify-binding-decorators";
 import {
   BackgroundMessageSender,
   newSender as newBackgroundMessageSender,
@@ -63,25 +11,28 @@ import {
   newSender as newWindowMessageSender,
 } from "./client/WindowMessageSender";
 
+import "./client/BackgroundKeyClient";
+import "./client/OperationClient";
+import "./client/SettingClient";
+import "./client/TopFrameClient";
+import "./presenters/ConsoleFramePresenter";
+import "./presenters/FindPresenter";
+import "./presenters/FocusPresenter";
+import "./presenters/HintPresenter";
+import "./presenters/NavigationPresenter";
+import "./presenters/ReadyStatusPresenter";
+import "./presenters/ScrollPresenter";
+import "./repositories/AddonEnabledRepository";
+import "./repositories/AddressRepository";
+import "./repositories/FrameIdRepository";
+import "./repositories/KeymapRepository";
+import "./repositories/ModeRepository";
+import "./repositories/SettingRepository";
+
 const container = new Container({ autoBindInjectable: true });
 
-container.bind(AddonEnabledRepository).to(AddonEnabledRepositoryImpl);
-container.bind(AddressRepository).to(AddressRepositoryImpl);
-container.bind(ConsoleFramePresenter).to(ConsoleFramePresenterImpl);
-container.bind(FocusPresenter).to(FocusPresenterImpl);
-container.bind(HintPresenter).to(HintPresenterImpl);
-container.bind(KeymapRepository).to(KeymapRepositoryImpl);
-container.bind(NavigationPresenter).to(NavigationPresenterImpl);
-container.bind(OperationClient).to(OperationClientImpl);
-container.bind(ScrollPresenter).to(ScrollPresenterImpl);
-container.bind(FindPresenter).to(FindPresenterImpl);
-container.bind(BackgroundKeyClient).to(BackgroundKeyClientImpl);
-container.bind(ModeRepository).to(ModeRepositoryImpl);
-container.bind(TopFrameClient).to(TopFrameClientImpl);
-container.bind(FrameIdRepository).to(FrameIdRepositoryImpl);
-container.bind(ReadyStatusPresenter).to(ReadyStatusPresenterImpl);
-container.bind(SettingClient).to(SettingClientImpl);
-container.bind(SettingRepository).to(SettingRepositoryImpl);
+container.load(buildProviderModule());
+
 container
   .bind(BackgroundMessageSender)
   .toConstantValue(newBackgroundMessageSender());

--- a/src/content/di.ts
+++ b/src/content/di.ts
@@ -1,50 +1,92 @@
 /* eslint-disable max-len */
 
-import { AddonEnabledRepositoryImpl } from "./repositories/AddonEnabledRepository";
-import { AddressRepositoryImpl } from "./repositories/AddressRepository";
-import { ConsoleFramePresenterImpl } from "./presenters/ConsoleFramePresenter";
-import { FocusPresenterImpl } from "./presenters/FocusPresenter";
-import { HintPresenterImpl } from "./presenters/HintPresenter";
-import { KeymapRepositoryImpl } from "./repositories/KeymapRepository";
-import { NavigationPresenterImpl } from "./presenters/NavigationPresenter";
-import { OperationClientImpl } from "./client/OperationClient";
-import { ScrollPresenterImpl } from "./presenters/ScrollPresenter";
-import { SettingClientImpl } from "./client/SettingClient";
-import { SettingRepositoryImpl } from "./repositories/SettingRepository";
-import { FindPresenterImpl } from "./presenters/FindPresenter";
-import { BackgroundKeyClientImpl } from "./client/BackgroundKeyClient";
-import { ModeRepositoryImpl } from "./repositories/ModeRepository";
-import { TopFrameClientImpl } from "./client/TopFrameClient";
-import { FrameIdRepositoryImpl } from "./repositories/FrameIdRepository";
-import { ReadyStatusPresenterImpl } from "./presenters/ReadyStatusPresenter";
+import {
+  AddonEnabledRepository,
+  AddonEnabledRepositoryImpl,
+} from "./repositories/AddonEnabledRepository";
+import {
+  AddressRepository,
+  AddressRepositoryImpl,
+} from "./repositories/AddressRepository";
+import {
+  ConsoleFramePresenter,
+  ConsoleFramePresenterImpl,
+} from "./presenters/ConsoleFramePresenter";
+import {
+  FocusPresenter,
+  FocusPresenterImpl,
+} from "./presenters/FocusPresenter";
+import { HintPresenter, HintPresenterImpl } from "./presenters/HintPresenter";
+import {
+  KeymapRepository,
+  KeymapRepositoryImpl,
+} from "./repositories/KeymapRepository";
+import {
+  NavigationPresenter,
+  NavigationPresenterImpl,
+} from "./presenters/NavigationPresenter";
+import { OperationClient, OperationClientImpl } from "./client/OperationClient";
+import {
+  ScrollPresenter,
+  ScrollPresenterImpl,
+} from "./presenters/ScrollPresenter";
+import { SettingClient, SettingClientImpl } from "./client/SettingClient";
+import {
+  SettingRepository,
+  SettingRepositoryImpl,
+} from "./repositories/SettingRepository";
+import { FindPresenter, FindPresenterImpl } from "./presenters/FindPresenter";
+import {
+  BackgroundKeyClient,
+  BackgroundKeyClientImpl,
+} from "./client/BackgroundKeyClient";
+import {
+  ModeRepository,
+  ModeRepositoryImpl,
+} from "./repositories/ModeRepository";
+import { TopFrameClient, TopFrameClientImpl } from "./client/TopFrameClient";
+import {
+  FrameIdRepository,
+  FrameIdRepositoryImpl,
+} from "./repositories/FrameIdRepository";
+import {
+  ReadyStatusPresenter,
+  ReadyStatusPresenterImpl,
+} from "./presenters/ReadyStatusPresenter";
 import { Container } from "inversify";
-import { newSender as newBackgroundMessageSender } from "./client/BackgroundMessageSender";
-import { newSender as newWindowMessageSender } from "./client/WindowMessageSender";
+import {
+  BackgroundMessageSender,
+  newSender as newBackgroundMessageSender,
+} from "./client/BackgroundMessageSender";
+import {
+  WindowMessageSender,
+  newSender as newWindowMessageSender,
+} from "./client/WindowMessageSender";
 
 const container = new Container({ autoBindInjectable: true });
 
-container.bind("AddonEnabledRepository").to(AddonEnabledRepositoryImpl);
-container.bind("AddressRepository").to(AddressRepositoryImpl);
-container.bind("ConsoleFramePresenter").to(ConsoleFramePresenterImpl);
-container.bind("FocusPresenter").to(FocusPresenterImpl);
-container.bind("HintPresenter").to(HintPresenterImpl);
-container.bind("KeymapRepository").to(KeymapRepositoryImpl);
-container.bind("NavigationPresenter").to(NavigationPresenterImpl);
-container.bind("OperationClient").to(OperationClientImpl);
-container.bind("ScrollPresenter").to(ScrollPresenterImpl);
-container.bind("FindPresenter").to(FindPresenterImpl);
-container.bind("BackgroundKeyClient").to(BackgroundKeyClientImpl);
-container.bind("ModeRepository").to(ModeRepositoryImpl);
-container.bind("TopFrameClient").to(TopFrameClientImpl);
-container.bind("FrameIdRepository").to(FrameIdRepositoryImpl);
-container.bind("ReadyStatusPresenter").to(ReadyStatusPresenterImpl);
-container.bind("SettingClient").to(SettingClientImpl);
-container.bind("SettingRepository").to(SettingRepositoryImpl);
+container.bind(AddonEnabledRepository).to(AddonEnabledRepositoryImpl);
+container.bind(AddressRepository).to(AddressRepositoryImpl);
+container.bind(ConsoleFramePresenter).to(ConsoleFramePresenterImpl);
+container.bind(FocusPresenter).to(FocusPresenterImpl);
+container.bind(HintPresenter).to(HintPresenterImpl);
+container.bind(KeymapRepository).to(KeymapRepositoryImpl);
+container.bind(NavigationPresenter).to(NavigationPresenterImpl);
+container.bind(OperationClient).to(OperationClientImpl);
+container.bind(ScrollPresenter).to(ScrollPresenterImpl);
+container.bind(FindPresenter).to(FindPresenterImpl);
+container.bind(BackgroundKeyClient).to(BackgroundKeyClientImpl);
+container.bind(ModeRepository).to(ModeRepositoryImpl);
+container.bind(TopFrameClient).to(TopFrameClientImpl);
+container.bind(FrameIdRepository).to(FrameIdRepositoryImpl);
+container.bind(ReadyStatusPresenter).to(ReadyStatusPresenterImpl);
+container.bind(SettingClient).to(SettingClientImpl);
+container.bind(SettingRepository).to(SettingRepositoryImpl);
 container
-  .bind("BackgroundMessageSender")
+  .bind(BackgroundMessageSender)
   .toConstantValue(newBackgroundMessageSender());
 container
-  .bind("WindowMessageSender")
+  .bind(WindowMessageSender)
   .toConstantValue(newWindowMessageSender(window.top!));
 
 export { container };

--- a/src/content/presenters/ConsoleFramePresenter.ts
+++ b/src/content/presenters/ConsoleFramePresenter.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 
 export interface ConsoleFramePresenter {
   attach(): void;
@@ -28,7 +28,7 @@ const FRAME_STYLES = {
 
 export const ConsoleFramePresenter = Symbol("ConsoleFramePresenter");
 
-@injectable()
+@provide(ConsoleFramePresenter)
 export class ConsoleFramePresenterImpl implements ConsoleFramePresenter {
   private static readonly IframeId = "vimmatic-console-frame" as const;
 

--- a/src/content/presenters/ConsoleFramePresenter.ts
+++ b/src/content/presenters/ConsoleFramePresenter.ts
@@ -26,6 +26,8 @@ const FRAME_STYLES = {
   "pointer-events": "none",
 } as const;
 
+export const ConsoleFramePresenter = Symbol("ConsoleFramePresenter");
+
 @injectable()
 export class ConsoleFramePresenterImpl implements ConsoleFramePresenter {
   private static readonly IframeId = "vimmatic-console-frame" as const;

--- a/src/content/presenters/FindPresenter.ts
+++ b/src/content/presenters/FindPresenter.ts
@@ -21,6 +21,8 @@ let currentQuery: {
 let finder: Finder | undefined;
 let textGroups: Array<Array<Text>> | undefined;
 
+export const FindPresenter = Symbol("FindPresenter");
+
 @injectable()
 export class FindPresenterImpl implements FindPresenter {
   findNext({ keyword, mode, ignoreCase }: FindQuery): boolean {

--- a/src/content/presenters/FindPresenter.ts
+++ b/src/content/presenters/FindPresenter.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import type { FindQuery } from "../../shared/findQuery";
 
 export interface FindPresenter {
@@ -23,7 +23,7 @@ let textGroups: Array<Array<Text>> | undefined;
 
 export const FindPresenter = Symbol("FindPresenter");
 
-@injectable()
+@provide(FindPresenter)
 export class FindPresenterImpl implements FindPresenter {
   findNext({ keyword, mode, ignoreCase }: FindQuery): boolean {
     this.initFinder({ keyword, mode, ignoreCase });

--- a/src/content/presenters/FocusPresenter.ts
+++ b/src/content/presenters/FocusPresenter.ts
@@ -4,6 +4,8 @@ export interface FocusPresenter {
   focusFirstElement(): boolean;
 }
 
+export const FocusPresenter = Symbol("FocusPresenter");
+
 @injectable()
 export class FocusPresenterImpl implements FocusPresenter {
   focusFirstElement(): boolean {

--- a/src/content/presenters/FocusPresenter.ts
+++ b/src/content/presenters/FocusPresenter.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 
 export interface FocusPresenter {
   focusFirstElement(): boolean;
@@ -6,7 +6,7 @@ export interface FocusPresenter {
 
 export const FocusPresenter = Symbol("FocusPresenter");
 
-@injectable()
+@provide(FocusPresenter)
 export class FocusPresenterImpl implements FocusPresenter {
   focusFirstElement(): boolean {
     const inputTypes = ["email", "number", "search", "tel", "text", "url"];

--- a/src/content/presenters/HintPresenter.ts
+++ b/src/content/presenters/HintPresenter.ts
@@ -1,5 +1,5 @@
 import { inject, injectable } from "inversify";
-import type { SettingRepository } from "../repositories/SettingRepository";
+import { SettingRepository } from "../repositories/SettingRepository";
 import { Hint } from "./Hint";
 import * as doms from "../../shared/utils/dom";
 import { HTMLElementLocator } from "./HTMLElementLocator";
@@ -80,10 +80,12 @@ export interface HintPresenter {
   clickElement(id: string): void;
 }
 
+export const HintPresenter = Symbol("HintPresenter");
+
 @injectable()
 export class HintPresenterImpl implements HintPresenter {
   constructor(
-    @inject("SettingRepository")
+    @inject(SettingRepository)
     private readonly settingRepository: SettingRepository,
   ) {}
 

--- a/src/content/presenters/HintPresenter.ts
+++ b/src/content/presenters/HintPresenter.ts
@@ -1,4 +1,5 @@
-import { inject, injectable } from "inversify";
+import { inject } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { SettingRepository } from "../repositories/SettingRepository";
 import { Hint } from "./Hint";
 import * as doms from "../../shared/utils/dom";
@@ -82,7 +83,7 @@ export interface HintPresenter {
 
 export const HintPresenter = Symbol("HintPresenter");
 
-@injectable()
+@provide(HintPresenter)
 export class HintPresenterImpl implements HintPresenter {
   constructor(
     @inject(SettingRepository)

--- a/src/content/presenters/NavigationPresenter.ts
+++ b/src/content/presenters/NavigationPresenter.ts
@@ -32,6 +32,8 @@ function selectLast<E extends Element>(
   return nodes.length ? nodes[nodes.length - 1] : null;
 }
 
+export const NavigationPresenter = Symbol("NavigationPresenter");
+
 @injectable()
 export class NavigationPresenterImpl implements NavigationPresenter {
   openHistoryPrev(): void {

--- a/src/content/presenters/NavigationPresenter.ts
+++ b/src/content/presenters/NavigationPresenter.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 
 export interface NavigationPresenter {
   openHistoryPrev(): void;
@@ -34,7 +34,7 @@ function selectLast<E extends Element>(
 
 export const NavigationPresenter = Symbol("NavigationPresenter");
 
-@injectable()
+@provide(NavigationPresenter)
 export class NavigationPresenterImpl implements NavigationPresenter {
   openHistoryPrev(): void {
     window.history.back();

--- a/src/content/presenters/ReadyStatusPresenter.ts
+++ b/src/content/presenters/ReadyStatusPresenter.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 
 export interface ReadyStatusPresenter {
   setContentReady(): void;
@@ -8,7 +8,7 @@ export interface ReadyStatusPresenter {
 
 export const ReadyStatusPresenter = Symbol("ReadyStatusPresenter");
 
-@injectable()
+@provide(ReadyStatusPresenter)
 export class ReadyStatusPresenterImpl {
   constructor(private readonly doc: Document = window.document) {}
   setContentReady() {

--- a/src/content/presenters/ReadyStatusPresenter.ts
+++ b/src/content/presenters/ReadyStatusPresenter.ts
@@ -6,6 +6,8 @@ export interface ReadyStatusPresenter {
   setConsoleReady(): void;
 }
 
+export const ReadyStatusPresenter = Symbol("ReadyStatusPresenter");
+
 @injectable()
 export class ReadyStatusPresenterImpl {
   constructor(private readonly doc: Document = window.document) {}

--- a/src/content/presenters/ScrollPresenter.ts
+++ b/src/content/presenters/ScrollPresenter.ts
@@ -128,8 +128,10 @@ export interface ScrollPresenter {
   scrollToEnd(smooth: boolean): void;
 }
 
+export const ScrollPresenter = Symbol("ScrollPresenter");
+
 @injectable()
-export class ScrollPresenterImpl {
+export class ScrollPresenterImpl implements ScrollPresenter {
   getScroll(): Point {
     const target = scrollTarget();
     return { x: target.scrollLeft, y: target.scrollTop };

--- a/src/content/presenters/ScrollPresenter.ts
+++ b/src/content/presenters/ScrollPresenter.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 
 const SCROLL_DELTA_X = 64;
 const SCROLL_DELTA_Y = 64;
@@ -130,7 +130,7 @@ export interface ScrollPresenter {
 
 export const ScrollPresenter = Symbol("ScrollPresenter");
 
-@injectable()
+@provide(ScrollPresenter)
 export class ScrollPresenterImpl implements ScrollPresenter {
   getScroll(): Point {
     const target = scrollTarget();

--- a/src/content/repositories/AddonEnabledRepository.ts
+++ b/src/content/repositories/AddonEnabledRepository.ts
@@ -8,6 +8,8 @@ export interface AddonEnabledRepository {
   isEnabled(): boolean;
 }
 
+export const AddonEnabledRepository = Symbol("AddonEnabledRepository");
+
 @injectable()
 export class AddonEnabledRepositoryImpl implements AddonEnabledRepository {
   set(on: boolean): void {

--- a/src/content/repositories/AddonEnabledRepository.ts
+++ b/src/content/repositories/AddonEnabledRepository.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 
 let enabled = false;
 
@@ -10,7 +10,7 @@ export interface AddonEnabledRepository {
 
 export const AddonEnabledRepository = Symbol("AddonEnabledRepository");
 
-@injectable()
+@provide(AddonEnabledRepository)
 export class AddonEnabledRepositoryImpl implements AddonEnabledRepository {
   set(on: boolean): void {
     enabled = on;

--- a/src/content/repositories/AddressRepository.ts
+++ b/src/content/repositories/AddressRepository.ts
@@ -4,6 +4,8 @@ export interface AddressRepository {
   getCurrentURL(): URL;
 }
 
+export const AddressRepository = Symbol("AddressRepository");
+
 @injectable()
 export class AddressRepositoryImpl implements AddressRepository {
   getCurrentURL(): URL {

--- a/src/content/repositories/AddressRepository.ts
+++ b/src/content/repositories/AddressRepository.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 
 export interface AddressRepository {
   getCurrentURL(): URL;
@@ -6,7 +6,7 @@ export interface AddressRepository {
 
 export const AddressRepository = Symbol("AddressRepository");
 
-@injectable()
+@provide(AddressRepository)
 export class AddressRepositoryImpl implements AddressRepository {
   getCurrentURL(): URL {
     return new URL(window.location.href);

--- a/src/content/repositories/FrameIdRepository.ts
+++ b/src/content/repositories/FrameIdRepository.ts
@@ -11,6 +11,8 @@ export interface FrameIdRepository {
 const targets: { [frameId: number]: Window } = {};
 const elements: { [frameId: number]: Element } = {};
 
+export const FrameIdRepository = Symbol("FrameIdRepository");
+
 @injectable()
 export class FrameIdRepositoryImpl implements FrameIdRepository {
   saveFrameId(frameId: number, target: Window, element: Element): void {

--- a/src/content/repositories/FrameIdRepository.ts
+++ b/src/content/repositories/FrameIdRepository.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 
 export interface FrameIdRepository {
   saveFrameId(frameId: number, target: Window, element: Element): void;
@@ -13,7 +13,7 @@ const elements: { [frameId: number]: Element } = {};
 
 export const FrameIdRepository = Symbol("FrameIdRepository");
 
-@injectable()
+@provide(FrameIdRepository)
 export class FrameIdRepositoryImpl implements FrameIdRepository {
   saveFrameId(frameId: number, target: Window, element: Element): void {
     targets[frameId] = target;

--- a/src/content/repositories/KeymapRepository.ts
+++ b/src/content/repositories/KeymapRepository.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import type { Key } from "../../shared/key";
 import { KeySequence } from "../domains/KeySequence";
 
@@ -12,7 +12,7 @@ let current: KeySequence = new KeySequence([]);
 
 export const KeymapRepository = Symbol("KeymapRepository");
 
-@injectable()
+@provide(KeymapRepository)
 export class KeymapRepositoryImpl implements KeymapRepository {
   enqueueKey(key: Key): KeySequence {
     current.push(key);

--- a/src/content/repositories/KeymapRepository.ts
+++ b/src/content/repositories/KeymapRepository.ts
@@ -10,6 +10,8 @@ export interface KeymapRepository {
 
 let current: KeySequence = new KeySequence([]);
 
+export const KeymapRepository = Symbol("KeymapRepository");
+
 @injectable()
 export class KeymapRepositoryImpl implements KeymapRepository {
   enqueueKey(key: Key): KeySequence {

--- a/src/content/repositories/ModeRepository.ts
+++ b/src/content/repositories/ModeRepository.ts
@@ -1,4 +1,4 @@
-import { injectable } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { Mode } from "../../shared/mode";
 
 let mode: Mode = Mode.Normal;
@@ -11,7 +11,7 @@ export interface ModeRepository {
 
 export const ModeRepository = Symbol("ModeRepository");
 
-@injectable()
+@provide(ModeRepository)
 export class ModeRepositoryImpl implements ModeRepository {
   getMode(): Mode {
     return mode;

--- a/src/content/repositories/ModeRepository.ts
+++ b/src/content/repositories/ModeRepository.ts
@@ -9,6 +9,8 @@ export interface ModeRepository {
   setMode(mode: Mode): void;
 }
 
+export const ModeRepository = Symbol("ModeRepository");
+
 @injectable()
 export class ModeRepositoryImpl implements ModeRepository {
   getMode(): Mode {

--- a/src/content/repositories/SettingRepository.ts
+++ b/src/content/repositories/SettingRepository.ts
@@ -1,4 +1,5 @@
-import { injectable, inject } from "inversify";
+import { inject } from "inversify";
+import { provide } from "inversify-binding-decorators";
 import { Blacklist } from "../../shared/blacklist";
 import type { Keymaps } from "../../shared/keymaps";
 import type { Properties } from "../../shared/properties";
@@ -26,7 +27,7 @@ export interface SettingRepository {
 
 export const SettingRepository = Symbol("SettingRepository");
 
-@injectable()
+@provide(SettingRepository)
 export class SettingRepositoryImpl implements SettingRepository {
   constructor(
     @inject(SettingClient)

--- a/src/content/repositories/SettingRepository.ts
+++ b/src/content/repositories/SettingRepository.ts
@@ -4,7 +4,7 @@ import type { Keymaps } from "../../shared/keymaps";
 import type { Properties } from "../../shared/properties";
 import type { Search } from "../../shared/search";
 import type { ComponentName, CSS } from "../../shared/styles";
-import type { SettingClient } from "../client/SettingClient";
+import { SettingClient } from "../client/SettingClient";
 import { defaultSettings } from "../../settings";
 import type { Settings } from "../../shared/settings";
 
@@ -24,10 +24,12 @@ export interface SettingRepository {
   getStyle(component: ComponentName): CSS;
 }
 
+export const SettingRepository = Symbol("SettingRepository");
+
 @injectable()
 export class SettingRepositoryImpl implements SettingRepository {
   constructor(
-    @inject("SettingClient")
+    @inject(SettingClient)
     private readonly client: SettingClient,
   ) {}
 

--- a/src/content/usecases/AddonEnabledUseCase.ts
+++ b/src/content/usecases/AddonEnabledUseCase.ts
@@ -1,13 +1,13 @@
 import { injectable, inject } from "inversify";
-import type { AddonEnabledRepository } from "../repositories/AddonEnabledRepository";
-import type { ConsoleFramePresenter } from "../presenters/ConsoleFramePresenter";
+import { AddonEnabledRepository } from "../repositories/AddonEnabledRepository";
+import { ConsoleFramePresenter } from "../presenters/ConsoleFramePresenter";
 
 @injectable()
 export class AddonEnabledUseCase {
   constructor(
-    @inject("AddonEnabledRepository")
+    @inject(AddonEnabledRepository)
     private readonly addonEnabledRepository: AddonEnabledRepository,
-    @inject("ConsoleFramePresenter")
+    @inject(ConsoleFramePresenter)
     private readonly consoleFramePresenter: ConsoleFramePresenter,
   ) {}
 

--- a/src/content/usecases/ConsoleFrameUseCase.ts
+++ b/src/content/usecases/ConsoleFrameUseCase.ts
@@ -1,13 +1,13 @@
 import { injectable, inject } from "inversify";
-import type { ConsoleFramePresenter } from "../presenters/ConsoleFramePresenter";
-import type { ReadyStatusPresenter } from "../presenters/ReadyStatusPresenter";
+import { ConsoleFramePresenter } from "../presenters/ConsoleFramePresenter";
+import { ReadyStatusPresenter } from "../presenters/ReadyStatusPresenter";
 
 @injectable()
 export class ConsoleFrameUseCase {
   constructor(
-    @inject("ConsoleFramePresenter")
+    @inject(ConsoleFramePresenter)
     private readonly consoleFramePresenter: ConsoleFramePresenter,
-    @inject("ReadyStatusPresenter")
+    @inject(ReadyStatusPresenter)
     private readonly readyStatusPresenter: ReadyStatusPresenter,
   ) {}
 

--- a/src/content/usecases/FindUseCase.ts
+++ b/src/content/usecases/FindUseCase.ts
@@ -1,11 +1,11 @@
 import { inject, injectable } from "inversify";
-import type { FindPresenter } from "../presenters/FindPresenter";
+import { FindPresenter } from "../presenters/FindPresenter";
 import type { FindQuery } from "../../shared/findQuery";
 
 @injectable()
 export class FindUseCase {
   constructor(
-    @inject("FindPresenter")
+    @inject(FindPresenter)
     private readonly findPresenter: FindPresenter,
   ) {}
 

--- a/src/content/usecases/FrameUseCase.ts
+++ b/src/content/usecases/FrameUseCase.ts
@@ -1,10 +1,10 @@
 import { injectable, inject } from "inversify";
-import type { TopFrameClient } from "../client/TopFrameClient";
+import { TopFrameClient } from "../client/TopFrameClient";
 
 @injectable()
 export class FrameUseCase {
   constructor(
-    @inject("TopFrameClient")
+    @inject(TopFrameClient)
     private readonly topFrameClient: TopFrameClient,
   ) {}
 

--- a/src/content/usecases/HintUseCase.ts
+++ b/src/content/usecases/HintUseCase.ts
@@ -1,11 +1,11 @@
 import { injectable, inject } from "inversify";
-import type { HintPresenter } from "../presenters/HintPresenter";
+import { HintPresenter } from "../presenters/HintPresenter";
 import type { HTMLElementType } from "../../shared/HTMLElementType";
 
 @injectable()
 export class HintUseCase {
   constructor(
-    @inject("HintPresenter")
+    @inject(HintPresenter)
     private readonly presenter: HintPresenter,
   ) {}
 

--- a/src/content/usecases/KeymapUseCase.ts
+++ b/src/content/usecases/KeymapUseCase.ts
@@ -1,9 +1,9 @@
 import { injectable, inject } from "inversify";
-import type { KeymapRepository } from "../repositories/KeymapRepository";
-import type { SettingRepository } from "../repositories/SettingRepository";
-import type { AddonEnabledRepository } from "../repositories/AddonEnabledRepository";
+import { KeymapRepository } from "../repositories/KeymapRepository";
+import { SettingRepository } from "../repositories/SettingRepository";
+import { AddonEnabledRepository } from "../repositories/AddonEnabledRepository";
 import type { Operation } from "../../shared/operation";
-import type { AddressRepository } from "../repositories/AddressRepository";
+import { AddressRepository } from "../repositories/AddressRepository";
 import { Keymaps } from "../../shared/keymaps";
 import type { Key } from "../../shared/key";
 import { KeySequence } from "../domains/KeySequence";
@@ -18,13 +18,13 @@ const enableAddonOps = ["addon.enable", "addon.toggle.enabled"];
 @injectable()
 export class KeymapUseCase {
   constructor(
-    @inject("KeymapRepository")
+    @inject(KeymapRepository)
     private readonly repository: KeymapRepository,
-    @inject("SettingRepository")
+    @inject(SettingRepository)
     private readonly settingRepository: SettingRepository,
-    @inject("AddonEnabledRepository")
+    @inject(AddonEnabledRepository)
     private readonly addonEnabledRepository: AddonEnabledRepository,
-    @inject("AddressRepository")
+    @inject(AddressRepository)
     private readonly addressRepository: AddressRepository,
   ) {}
 

--- a/src/content/usecases/NavigateUseCase.ts
+++ b/src/content/usecases/NavigateUseCase.ts
@@ -1,10 +1,10 @@
 import { injectable, inject } from "inversify";
-import type { NavigationPresenter } from "../presenters/NavigationPresenter";
+import { NavigationPresenter } from "../presenters/NavigationPresenter";
 
 @injectable()
 export class NavigateUseCase {
   constructor(
-    @inject("NavigationPresenter")
+    @inject(NavigationPresenter)
     private readonly navigationPresenter: NavigationPresenter,
   ) {}
 

--- a/src/content/usecases/OperationUseCase.ts
+++ b/src/content/usecases/OperationUseCase.ts
@@ -1,11 +1,11 @@
 import { injectable, inject } from "inversify";
-import type { OperationClient } from "../client/OperationClient";
+import { OperationClient } from "../client/OperationClient";
 import type { Operation } from "../../shared/operation";
 
 @injectable()
 export class OperationUseCase {
   constructor(
-    @inject("OperationClient")
+    @inject(OperationClient)
     private readonly operationClient: OperationClient,
   ) {}
 

--- a/src/content/usecases/TopFrameUseCase.ts
+++ b/src/content/usecases/TopFrameUseCase.ts
@@ -1,10 +1,10 @@
 import { injectable, inject } from "inversify";
-import type { FrameIdRepository } from "../repositories/FrameIdRepository";
+import { FrameIdRepository } from "../repositories/FrameIdRepository";
 
 @injectable()
 export class TopFrameUseCase {
   constructor(
-    @inject("FrameIdRepository")
+    @inject(FrameIdRepository)
     private readonly frameIdRepository: FrameIdRepository,
   ) {}
 

--- a/test/background/operators/impls/RepeatLastOperator.test.ts
+++ b/test/background/operators/impls/RepeatLastOperator.test.ts
@@ -1,6 +1,6 @@
 import { RepeatLastOperator } from "../../../../src/background/operators/impls/RepeatLastOperator";
 import type { RepeatRepository } from "../../../../src/background/repositories/RepeatRepository";
-import type { OperatorRegistory } from "../../../../src/background/operators/OperatorRegistory";
+import type { OperatorRegistry } from "../../../../src/background/operators/OperatorRegistry";
 import type {
   Operator,
   OperatorContext,
@@ -12,7 +12,7 @@ const todo = () => {
 };
 
 describe("RepeatLastOperator", () => {
-  const operatorRegistory: OperatorRegistory = {
+  const operatorRegistry: OperatorRegistry = {
     register: todo,
     getOperator: todo,
   };
@@ -26,7 +26,7 @@ describe("RepeatLastOperator", () => {
     run: todo,
   };
   const ctx = {} as OperatorContext;
-  const sut = new RepeatLastOperator(operatorRegistory, repeatRepository);
+  const sut = new RepeatLastOperator(operatorRegistry, repeatRepository);
 
   const mockRun = vi.spyOn(operator, "run").mockResolvedValue();
 
@@ -40,7 +40,7 @@ describe("RepeatLastOperator", () => {
         type: "greeting",
         props: { name: "alice" },
       });
-      vi.spyOn(operatorRegistory, "getOperator").mockReturnValue(operator);
+      vi.spyOn(operatorRegistry, "getOperator").mockReturnValue(operator);
 
       await sut.run(ctx);
 
@@ -60,7 +60,7 @@ describe("RepeatLastOperator", () => {
         type: "unknown",
         props: {},
       });
-      vi.spyOn(operatorRegistory, "getOperator").mockReturnValue(undefined);
+      vi.spyOn(operatorRegistry, "getOperator").mockReturnValue(undefined);
 
       await expect(() => sut.run(ctx)).rejects.toThrow();
     });

--- a/test/background/settings/SettingsRepository.test.ts
+++ b/test/background/settings/SettingsRepository.test.ts
@@ -1,15 +1,15 @@
 import {
-  PermanentSettingsRepository,
-  TransientSettingsRepository,
+  PermanentSettingsRepositoryImpl,
+  TransientSettingsRepositoryImpl,
 } from "../../../src/background/settings/SettingsRepository";
 import type { Settings } from "../../../src/shared/settings";
 import { MockLocalStorage } from "../mock/MockLocalStorage";
 import { describe, beforeEach, it, vi, expect } from "vitest";
 
-describe("PermanentSettingsRepository", () => {
+describe("PermanentSettingsRepositoryImpl", () => {
   const mockStorageGet = vi.spyOn(chrome.storage.sync, "get");
 
-  const sut = new PermanentSettingsRepository();
+  const sut = new PermanentSettingsRepositoryImpl();
 
   beforeEach(() => {
     mockStorageGet.mockClear();
@@ -68,7 +68,7 @@ class MockSettingsRepository {
   }
 }
 
-describe("TransientSettingsRepository", () => {
+describe("TransientSettingsRepositoryImpl", () => {
   const permanent = new MockSettingsRepository();
   const mockPermanetLoad = vi.spyOn(permanent, "load");
 
@@ -83,7 +83,7 @@ describe("TransientSettingsRepository", () => {
   });
 
   describe("#load", () => {
-    const sut = new TransientSettingsRepository(
+    const sut = new TransientSettingsRepositoryImpl(
       permanent,
       new MockLocalStorage(undefined),
     );
@@ -100,7 +100,7 @@ describe("TransientSettingsRepository", () => {
   });
 
   describe("#save", () => {
-    const sut = new TransientSettingsRepository(
+    const sut = new TransientSettingsRepositoryImpl(
       permanent,
       new MockLocalStorage(undefined),
     );
@@ -117,7 +117,7 @@ describe("TransientSettingsRepository", () => {
   });
 
   describe("#sync", () => {
-    const sut = new TransientSettingsRepository(
+    const sut = new TransientSettingsRepositoryImpl(
       permanent,
       new MockLocalStorage(undefined),
     );

--- a/test/background/settings/Validator.test.ts
+++ b/test/background/settings/Validator.test.ts
@@ -1,6 +1,6 @@
 import { Validator } from "../../../src/background/settings/Validator";
 import { createPropertyRegistry } from "../../../src/background/property";
-import { OperatorRegistryImpl } from "../../../src/background/operators/OperatorRegistory";
+import { OperatorRegistryImpl } from "../../../src/background/operators/OperatorRegistry";
 import { CloseTabOperator } from "../../../src/background/operators/impls/CloseTabOperator";
 import { DuplicateTabOperator } from "../../../src/background/operators/impls/DuplicateTabOperator";
 import { Keymaps } from "../../../src/shared/keymaps";
@@ -8,11 +8,11 @@ import { Search } from "../../../src/shared/search";
 import { describe, test, expect } from "vitest";
 
 describe("Validator", () => {
-  const operatorRegistory = new OperatorRegistryImpl();
-  operatorRegistory.register(new CloseTabOperator());
-  operatorRegistory.register(new DuplicateTabOperator());
+  const operatorRegistry = new OperatorRegistryImpl();
+  operatorRegistry.register(new CloseTabOperator());
+  operatorRegistry.register(new DuplicateTabOperator());
 
-  const sut = new Validator(createPropertyRegistry(), operatorRegistory);
+  const sut = new Validator(createPropertyRegistry(), operatorRegistry);
 
   test("it do nothing on valid settings", () => {
     sut.validate({});


### PR DESCRIPTION
This PR includes two concepts of refactoring.
- Migrate tokens at `@inject()` of inversify with the Symbol instead of using a string. Using symbols is more robust than string.
- Use [inversify-binding-decorators](https://github.com/inversify/inversify-binding-decorators) to bind class instead of binding manually.