### PR TITLE
fix: list-up links without overlapped

### DIFF
--- a/src/content/presenters/HintPresenter.ts
+++ b/src/content/presenters/HintPresenter.ts
@@ -181,16 +181,28 @@ export class HintPresenterImpl implements HintPresenter {
     framePosition: Point,
   ): boolean {
     // AREA's 'display' in Browser style is 'none'
-    return (
-      element.checkVisibility({
-        contentVisibilityAuto: true,
-        opacityProperty: true,
-        visibilityProperty: true,
-      }) &&
-      isAriaVisible(window, element) &&
-      isElementIsNotOverlapped(element) &&
-      inViewport(window, element, viewSize, framePosition)
-    );
+    if (element instanceof HTMLAreaElement) {
+      return (
+        element.checkVisibility({
+          contentVisibilityAuto: true,
+          opacityProperty: true,
+          visibilityProperty: true,
+        }) &&
+        isAriaVisible(window, element) &&
+        inViewport(window, element, viewSize, framePosition)
+      );
+    } else {
+      return (
+        element.checkVisibility({
+          contentVisibilityAuto: true,
+          opacityProperty: true,
+          visibilityProperty: true,
+        }) &&
+        isAriaVisible(window, element) &&
+        isElementIsNotOverlapped(element) &&
+        inViewport(window, element, viewSize, framePosition)
+      );
+    }
   }
 
   getElement(elementId: string): HTMLElementType | undefined {

--- a/test/main.ts
+++ b/test/main.ts
@@ -76,3 +76,6 @@ global.chrome = {
 if (global.Element) {
   global.Element.prototype.checkVisibility = () => true;
 }
+if (global.Document) {
+  global.Document.prototype.elementFromPoint = () => null;
+}


### PR DESCRIPTION
This change improve listing-up links on the following hints mode. It checks HTML visibilities by using `document.elementFromPoint` to ignore overlapped by other elements or cropped by the parent elements.