### PR TITLE
fix: replace Twitter references with X

### DIFF
--- a/docs/search_engines.md
+++ b/docs/search_engines.md
@@ -19,7 +19,7 @@ replaced with the search keyword parameters of the command.
       "yahoo": "https://search.yahoo.com/search?p={}",
       "bing": "https://www.bing.com/search?q={}",
       "duckduckgo": "https://duckduckgo.com/?q={}",
-      "twitter": "https://twitter.com/search?q={}",
+      "x": "https://x.com/search?q={}",
       "wikipedia": "https://en.wikipedia.org/w/index.php?search={}"
     }
   }

--- a/src/settings/default.ts
+++ b/src/settings/default.ts
@@ -83,7 +83,7 @@ export const defaultJSONSettings = `{
       "yahoo": "https://search.yahoo.com/search?p={}",
       "bing": "https://www.bing.com/search?q={}",
       "duckduckgo": "https://duckduckgo.com/?q={}",
-      "twitter": "https://twitter.com/search?q={}",
+      "x": "https://x.com/search?q={}",
       "wikipedia": "https://en.wikipedia.org/w/index.php?search={}"
     }
   },

--- a/test/console/completion/components/CompletionItem.test.tsx
+++ b/test/console/completion/components/CompletionItem.test.tsx
@@ -12,13 +12,13 @@ describe("console/components/console/completion/CompletionItem", () => {
       <CompletionItem
         shown={true}
         highlight={false}
-        primary="twitter"
-        secondary="https://twitter.com/"
+        primary="x"
+        secondary="https://x.com/"
       />,
     );
 
     const item = screen.getByRole("menuitem");
-    expect(item.textContent).toContain("twitter");
-    expect(item.textContent).toContain("https://twitter.com/");
+    expect(item.textContent).toContain("x");
+    expect(item.textContent).toContain("https://x.com/");
   });
 });


### PR DESCRIPTION
Updated search engine configuration and tests to use X instead of Twitter, reflecting the platform's rebranding.

🤖 Generated with [Claude Code](https://claude.ai/code) 