### PR TITLE
fix: stabilize background-content messaging with a readiness handshake

### DIFF
--- a/src/background/Application.ts
+++ b/src/background/Application.ts
@@ -88,8 +88,13 @@ export class Application {
       return;
     }
 
-    await this.frameClient.notifyFrameId(tabId, frameId);
+    // Register the frame as ready first, so the readiness invariant (a frame in
+    // the repository is able to receive messages) holds before we send anything
+    // to it.  The port `onConnect` fires only after the content script has
+    // installed its message listener, so the frame is guaranteed to be
+    // listening at this point.
     await this.frameRepository.addFrameId(tabId, frameId);
+    await this.frameClient.notifyFrameId(tabId, frameId);
   }
 
   private async onFindPortDisconnect(port: chrome.runtime.Port) {

--- a/src/background/clients/ContentMessageSender.ts
+++ b/src/background/clients/ContentMessageSender.ts
@@ -1,6 +1,13 @@
 import type { Schema, Key, Request } from "../../messaging/schema/content";
 import { Sender } from "../../messaging";
 
+// Sends a message to a content script.  The receiving frame is guaranteed to be
+// listening because the background only ever sends to frames that are present
+// in `ReadyFrameRepository`, and a frame is registered there only after its
+// content script has finished installing its `chrome.runtime.onMessage`
+// listener (see `content/Application.ts`).  Therefore no retry is performed
+// here; a failure is a genuine error (e.g. the frame has already navigated
+// away) and is surfaced to the caller.
 export const newSender = (tabId: number, frameId?: number) => {
   const sender = new Sender<Schema>((type: Key, args: Request) => {
     if (process.env.NODE_ENV === "development") {

--- a/src/background/repositories/ReadyFrameRepository.ts
+++ b/src/background/repositories/ReadyFrameRepository.ts
@@ -15,6 +15,20 @@ export const ReadyFrameRepository = Symbol("ReadyFrameRepository");
 
 @provide(ReadyFrameRepository)
 export class ReadyFrameRepositoryImpl implements ReadyFrameRepository {
+  // Serializes all mutations so that the read-modify-write against the backing
+  // `chrome.storage.local` cache cannot interleave.  Bursty port
+  // connect/disconnect events (many frames loading/unloading at once) would
+  // otherwise run overlapping getValue -> setValue cycles and clobber each
+  // other, causing the frame list to drift out of sync with reality.
+  //
+  // A frame is registered here only after its content script has installed its
+  // `chrome.runtime.onMessage` listener (the content script opens its port only
+  // after `listen()`), so membership in this repository is the readiness
+  // handshake: if a frame is present, it is able to receive messages.  The
+  // background sends to a frame only once it is registered here, which removes
+  // the send/receive race and the need for retries on the send side.
+  private queue: Promise<void> = Promise.resolve();
+
   constructor(
     private readonly cache: LocalCache<State> = new LocalCacheImpl(
       ReadyFrameRepositoryImpl.name,
@@ -22,42 +36,53 @@ export class ReadyFrameRepositoryImpl implements ReadyFrameRepository {
     ),
   ) {}
 
-  async addFrameId(tabId: number, frameId: number): Promise<void> {
-    const state = await this.cache.getValue();
-
-    if (frameId === 0) {
-      // top frame is reloaded, flush frame IDs
-      state[tabId] = [frameId];
-    } else {
-      const s = new Set(state[tabId]);
-      s.add(frameId);
-      state[tabId] = Array.from(s);
-    }
-    await this.cache.setValue(state);
+  private enqueue(task: () => Promise<void>): Promise<void> {
+    const next = this.queue.then(task, task);
+    // Keep the chain alive even if a task rejects.
+    this.queue = next.catch(() => undefined);
+    return next;
   }
 
-  async removeFrameId(tabId: number, frameId: number): Promise<void> {
-    const state = await this.cache.getValue();
-    const ids = state[tabId];
-    if (typeof ids === "undefined") {
-      return;
-    }
+  addFrameId(tabId: number, frameId: number): Promise<void> {
+    return this.enqueue(async () => {
+      const state = await this.cache.getValue();
 
-    if (frameId === 0) {
-      // top frame is closed, flush frame IDs
-      delete state[tabId];
-    } else {
-      const s = new Set(ids);
-      s.delete(frameId);
-
-      if (s.size === 0) {
-        delete state[frameId];
+      if (frameId === 0) {
+        // top frame is reloaded, flush frame IDs
+        state[tabId] = [frameId];
       } else {
+        const s = new Set(state[tabId]);
+        s.add(frameId);
         state[tabId] = Array.from(s);
       }
-    }
+      await this.cache.setValue(state);
+    });
+  }
 
-    await this.cache.setValue(state);
+  removeFrameId(tabId: number, frameId: number): Promise<void> {
+    return this.enqueue(async () => {
+      const state = await this.cache.getValue();
+      const ids = state[tabId];
+      if (typeof ids === "undefined") {
+        return;
+      }
+
+      if (frameId === 0) {
+        // top frame is closed, flush frame IDs
+        delete state[tabId];
+      } else {
+        const s = new Set(ids);
+        s.delete(frameId);
+
+        if (s.size === 0) {
+          delete state[tabId];
+        } else {
+          state[tabId] = Array.from(s);
+        }
+      }
+
+      await this.cache.setValue(state);
+    });
   }
 
   async getFrameIds(tabId: number): Promise<number[] | undefined> {

--- a/src/content/Application.ts
+++ b/src/content/Application.ts
@@ -4,6 +4,7 @@ import { ContentMessageListener } from "./messaging/ContentMessageListener";
 import { KeyController } from "./controllers/KeyController";
 import { SettingsController } from "./controllers/SettingsController";
 import { InputDriver } from "./InputDriver";
+import { PortConnector } from "./PortConnector";
 import { ReadyStatusPresenter } from "./presenters/ReadyStatusPresenter";
 
 @injectable()
@@ -21,22 +22,36 @@ export class Application {
     private readonly readyStatusPresenter: ReadyStatusPresenter,
   ) {}
 
+  private readonly portConnector = new PortConnector();
+
   init(): Promise<void> {
     if (window === window.top) {
       this.windowMessageListener.listen();
     }
+
+    // Install the message listener BEFORE announcing readiness.  This ordering
+    // is the readiness handshake: the background only sends messages to frames
+    // it has registered in `ReadyFrameRepository`, and that registration is
+    // driven by the port connection opened below.  By registering the
+    // `chrome.runtime.onMessage` listener first, we guarantee that by the time
+    // the background learns about this frame (via the port `onConnect`), the
+    // frame is already able to receive messages.  This removes the send/receive
+    // race that previously required retries on the background side.
     this.contentMessageListener.listen();
+
     this.routeFocusEvents();
     this.routeKeymaps();
     this.settingsController.initSettings();
 
-    // Ping to background script and notify content script is ready with its
-    // frame id.  Background script gathers frame ids on the tab and use them
-    // when it communicate with each frames.
+    // Open a long-lived port to the background as the readiness signal.  The
+    // port itself carries no data; messages are delivered via
+    // `chrome.tabs.sendMessage` with a frame ID.  Its `onConnect` on the
+    // background side is what registers this (now listening) frame as ready.
     //
-    // The port is never used, and the messages are delivered via
-    // `chrome.tabs.sendMessage` API with a frame ID.
-    chrome.runtime.connect({ name: "vimmatic-port" });
+    // The port is reconnected automatically when it is disconnected (e.g. the
+    // MV3 background service worker is terminated) so the frame re-registers
+    // itself, and re-announces its readiness, to a freshly started background.
+    this.portConnector.start();
 
     this.readyStatusPresenter.setContentReady();
 

--- a/src/content/PortConnector.ts
+++ b/src/content/PortConnector.ts
@@ -1,0 +1,71 @@
+const PORT_NAME = "vimmatic-port";
+const RECONNECT_DELAY_MS = 1000;
+
+// PortConnector keeps a long-lived `chrome.runtime.connect` port open toward the
+// background script.  The port itself carries no data; it is only a liveness
+// signal so the background can learn this frame's frame ID (via
+// `port.sender.frameId`) and detect when the frame goes away.
+//
+// On Manifest V3 the background runs as a terminable service worker (Chrome) or
+// non-persistent event page (Firefox).  When it is terminated the port is
+// disconnected on this side too.  Without reconnecting, the background would
+// never re-learn this frame after it restarts, so features silently stop
+// working until a full page reload.  This class reconnects on disconnect so the
+// frame re-registers itself with a freshly started background.
+export class PortConnector {
+  private port?: chrome.runtime.Port;
+  private disposed = false;
+  private reconnectTimer?: ReturnType<typeof setTimeout>;
+
+  constructor(
+    private readonly delayMs: number = RECONNECT_DELAY_MS,
+    private readonly connect: (
+      connectInfo: chrome.runtime.ConnectInfo,
+    ) => chrome.runtime.Port = (connectInfo) =>
+      chrome.runtime.connect(connectInfo),
+  ) {}
+
+  start(): void {
+    this.disposed = false;
+    this.open();
+  }
+
+  stop(): void {
+    this.disposed = true;
+    if (typeof this.reconnectTimer !== "undefined") {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+    }
+    this.port?.disconnect();
+    this.port = undefined;
+  }
+
+  private open(): void {
+    if (this.disposed) {
+      return;
+    }
+
+    const port = this.connect({ name: PORT_NAME });
+    this.port = port;
+    port.onDisconnect.addListener(() => this.onDisconnect(port));
+  }
+
+  private onDisconnect(port: chrome.runtime.Port): void {
+    // Ignore stale disconnects from a port we have already replaced.
+    if (this.port !== port || this.disposed) {
+      return;
+    }
+    this.port = undefined;
+    this.scheduleReconnect();
+  }
+
+  private scheduleReconnect(): void {
+    if (this.disposed || typeof this.reconnectTimer !== "undefined") {
+      return;
+    }
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = undefined;
+      this.open();
+    }, this.delayMs);
+  }
+}

--- a/test/background/clients/ContentMessageSender.test.ts
+++ b/test/background/clients/ContentMessageSender.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { newSender } from "../../../src/background/clients/ContentMessageSender";
+
+describe("ContentMessageSender", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends a message with the tab id and frame id", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ x: 1, y: 2 });
+    (global.chrome as any).tabs.sendMessage = sendMessage;
+
+    const sender = newSender(10, 3);
+    const result = await sender.send("get.scroll");
+
+    expect(result).toEqual({ x: 1, y: 2 });
+    expect(sendMessage).toHaveBeenCalledWith(
+      10,
+      { type: "get.scroll", args: {} },
+      { frameId: 3 },
+    );
+  });
+
+  it("sends only once and surfaces the error without retrying", async () => {
+    const err = new Error(
+      "Could not establish connection. Receiving end does not exist.",
+    );
+    const sendMessage = vi.fn().mockRejectedValue(err);
+    (global.chrome as any).tabs.sendMessage = sendMessage;
+
+    const sender = newSender(10, 0);
+    await expect(sender.send("settings.changed")).rejects.toThrow(
+      "Could not establish connection.",
+    );
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/background/repositories/ReadyFrameRepository.test.ts
+++ b/test/background/repositories/ReadyFrameRepository.test.ts
@@ -1,4 +1,5 @@
 import { ReadyFrameRepositoryImpl } from "../../../src/background/repositories/ReadyFrameRepository";
+import type { LocalCache } from "../../../src/background/db/LocalStorage";
 import { MockLocalStorage } from "../mock/MockLocalStorage";
 import { describe, it, expect } from "vitest";
 
@@ -45,5 +46,43 @@ describe("ReadyFrameRepositoryImpl", () => {
 
     await sut.removeFrameId(2, 20);
     expect(await sut.getFrameIds(2)).toBeUndefined;
+  });
+
+  it("clears the tab entry when the last non-top frame is removed", async () => {
+    const repo = new ReadyFrameRepositoryImpl(new MockLocalStorage({}));
+
+    await repo.addFrameId(5, 50);
+    expect(await repo.getFrameIds(5)).toEqual([50]);
+
+    await repo.removeFrameId(5, 50);
+    // The tab entry (tabId=5) must be cleared, not some unrelated key.
+    expect(await repo.getFrameIds(5)).toBeUndefined();
+  });
+
+  it("serializes concurrent mutations without clobbering", async () => {
+    // A cache whose getValue/setValue resolve on the microtask queue so that
+    // unsynchronized read-modify-write cycles would interleave and lose writes.
+    class AsyncCache implements LocalCache<{ [tabId: number]: number[] }> {
+      private value: { [tabId: number]: number[] } = {};
+      async getValue() {
+        await Promise.resolve();
+        return JSON.parse(JSON.stringify(this.value));
+      }
+      async setValue(value: { [tabId: number]: number[] }) {
+        await Promise.resolve();
+        this.value = JSON.parse(JSON.stringify(value));
+      }
+    }
+
+    const repo = new ReadyFrameRepositoryImpl(new AsyncCache());
+
+    await Promise.all([
+      repo.addFrameId(1, 10),
+      repo.addFrameId(1, 11),
+      repo.addFrameId(1, 12),
+      repo.addFrameId(1, 13),
+    ]);
+
+    expect(await repo.getFrameIds(1)).toEqual([10, 11, 12, 13]);
   });
 });

--- a/test/content/PortConnector.test.ts
+++ b/test/content/PortConnector.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { PortConnector } from "../../src/content/PortConnector";
+
+class FakePort {
+  disconnected = false;
+  private readonly listeners: Array<() => void> = [];
+  readonly onDisconnect = {
+    addListener: (cb: () => void) => {
+      this.listeners.push(cb);
+    },
+  };
+
+  disconnect() {
+    this.disconnected = true;
+  }
+
+  // Simulate the background terminating the port.
+  fireDisconnect() {
+    for (const cb of this.listeners) {
+      cb();
+    }
+  }
+}
+
+describe("PortConnector", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("opens a port named vimmatic-port on start", () => {
+    const connect = vi.fn(
+      () => new FakePort() as unknown as chrome.runtime.Port,
+    );
+    const connector = new PortConnector(1000, connect);
+
+    connector.start();
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(connect).toHaveBeenCalledWith({ name: "vimmatic-port" });
+  });
+
+  it("reconnects after the port is disconnected", () => {
+    const ports: FakePort[] = [];
+    const connect = vi.fn(() => {
+      const port = new FakePort();
+      ports.push(port);
+      return port as unknown as chrome.runtime.Port;
+    });
+    const connector = new PortConnector(1000, connect);
+
+    connector.start();
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    ports[0].fireDisconnect();
+    // Reconnect is scheduled, not immediate.
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1000);
+    expect(connect).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps reconnecting on repeated disconnects", () => {
+    const ports: FakePort[] = [];
+    const connect = vi.fn(() => {
+      const port = new FakePort();
+      ports.push(port);
+      return port as unknown as chrome.runtime.Port;
+    });
+    const connector = new PortConnector(1000, connect);
+
+    connector.start();
+    ports[0].fireDisconnect();
+    vi.advanceTimersByTime(1000);
+    ports[1].fireDisconnect();
+    vi.advanceTimersByTime(1000);
+
+    expect(connect).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not reconnect after stop()", () => {
+    const ports: FakePort[] = [];
+    const connect = vi.fn(() => {
+      const port = new FakePort();
+      ports.push(port);
+      return port as unknown as chrome.runtime.Port;
+    });
+    const connector = new PortConnector(1000, connect);
+
+    connector.start();
+    connector.stop();
+    expect(ports[0].disconnected).toBe(true);
+
+    ports[0].fireDisconnect();
+    vi.advanceTimersByTime(1000);
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Intermittent background<->content connection loss came from the MV3 background (Chrome service worker / Firefox non-persistent event page) being terminated and from send/receive races against not-yet-listening content frames.

- content: reconnect the vimmatic-port automatically when it is disconnected (e.g. on service worker termination) so the frame re-registers with a freshly started background (PortConnector)
- content: install the onMessage listener before opening the port, so the port connection doubles as a readiness handshake
- background: register a frame as ready before sending to it, keeping the invariant that a frame in ReadyFrameRepository can receive
- background: drop send-side retries; a send failure is now a genuine error rather than a race to paper over
- ReadyFrameRepository: serialize the read-modify-write against chrome.storage.local to avoid lost updates under bursty connects
- ReadyFrameRepository: fix removeFrameId deleting the wrong key (state[frameId] -> state[tabId]) when the last non-top frame is removed